### PR TITLE
fix: use bleak-retry-connector for reliable BLE connection

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
+from bleak_retry_connector import establish_connection
 
 from .const import (
     AUTH_STEP_DELAY,
@@ -224,9 +225,12 @@ class PetkitBleClient:
     # ------------------------------------------------------------------
 
     async def _connect(self) -> None:
-        """Establish BLE connection and start notifications."""
-        self._client = BleakClient(self._device)
-        await self._client.connect()
+        """Establish BLE connection using bleak-retry-connector for reliability."""
+        self._client = await establish_connection(
+            BleakClient,
+            self._device,
+            self._device.address,
+        )
         await self._client.start_notify(BLE_NOTIFY_UUID, self._on_notify)
         self._rx_buf.clear()
         self._seq = 0

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -5,9 +5,9 @@
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",
-  "requirements": ["bleak>=0.22.0"],
-  "dependencies": ["bluetooth"],
-  "after_dependencies": ["bluetooth_adapters"],
+  "requirements": ["bleak>=0.22.0", "bleak-retry-connector>=3.0.0"],
+  "dependencies": ["bluetooth", "bluetooth_adapters"],
+  "after_dependencies": [],
   "bluetooth": [
     {"connectable": true, "local_name": "Petkit_W4*"},
     {"connectable": true, "local_name": "Petkit_W5*"},


### PR DESCRIPTION
## Problem
HA logged this warning 28+ times:
\\\
A4:C1:38:E6:2B:1C: BleakClient.connect() called without bleak-retry-connector.
For reliable connection establishment, use bleak_retry_connector.establish_connection()
\\\

## Fix
- Replace \BleakClient(...); await client.connect()\ with \stablish_connection(BleakClient, device, address)\
- Add \leak-retry-connector>=3.0.0\ to manifest requirements
- Move \luetooth_adapters\ from \fter_dependencies\ to \dependencies\ (required by retry connector)

## Why
\leak_retry_connector\ handles transient BLE connection failures automatically with exponential backoff, which is required for production-quality BLE integrations in Home Assistant.