### PR TITLE
fix: replace removed UnitOfSignalStrength with SIGNAL_STRENGTH_DECIBELS_MILLIWATT

### DIFF
--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -14,10 +14,10 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfElectricPotential,
     UnitOfEnergy,
-    UnitOfSignalStrength,
     UnitOfTime,
     UnitOfVolume,
 )
@@ -115,7 +115,7 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
     PetkitSensorEntityDescription(
         key="rssi",
         translation_key="rssi",
-        native_unit_of_measurement=UnitOfSignalStrength.DECIBELS_MILLIWATT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
## Problem
UnitOfSignalStrength has been removed from homeassistant.const in newer HA versions (Python 3.14+), causing:

\\\
ImportError: cannot import name 'UnitOfSignalStrength' from 'homeassistant.const'
\\\

## Fix
Replace UnitOfSignalStrength.DECIBELS_MILLIWATT with the direct constant SIGNAL_STRENGTH_DECIBELS_MILLIWATT which is still present in homeassistant.const.

## Changes
- sensor.py: Updated import and RSSI sensor unit reference