### PR TITLE
fix: serialize BLE access via coordinator lock, fix mode validation

### DIFF
--- a/custom_components/petkit_ble/button.py
+++ b/custom_components/petkit_ble/button.py
@@ -6,13 +6,11 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from homeassistant.components.bluetooth import async_ble_device_from_address
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .ble_client import PetkitBleClient
-from .const import CMD_RESET_FILTER, CMD_SET_POWER_MODE, CONF_ADDRESS, CONF_MODEL
+from .const import CMD_RESET_FILTER, CMD_SET_POWER_MODE
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
 
@@ -31,12 +29,14 @@ def _reset_filter_cmds(_coordinator: PetkitBleCoordinator) -> list[tuple[int, li
 
 
 def _pump_on_cmds(coordinator: PetkitBleCoordinator) -> list[tuple[int, list[int]]]:
-    mode = coordinator.data.mode if coordinator.data else 1
+    raw_mode = coordinator.data.mode if coordinator.data else 1
+    mode = raw_mode if raw_mode in (1, 2) else 1
     return [(CMD_SET_POWER_MODE, [1, mode])]
 
 
 def _pump_off_cmds(coordinator: PetkitBleCoordinator) -> list[tuple[int, list[int]]]:
-    mode = coordinator.data.mode if coordinator.data else 1
+    raw_mode = coordinator.data.mode if coordinator.data else 1
+    mode = raw_mode if raw_mode in (1, 2) else 1
     return [(CMD_SET_POWER_MODE, [0, mode])]
 
 
@@ -85,17 +85,8 @@ class PetkitBleButton(PetkitBleEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Send the button command to the device."""
-        address: str = self.coordinator.config_entry.data[CONF_ADDRESS]
-        alias: str = self.coordinator.config_entry.data[CONF_MODEL]
-
-        ble_device = async_ble_device_from_address(self.coordinator.hass, address, connectable=True)
-        if ble_device is None:
-            _LOGGER.warning("Cannot press %s: device %s not found", self.entity_description.key, address)
-            return
-
-        client = PetkitBleClient(ble_device)
         for cmd, data in self.entity_description.press_fn(self.coordinator):
-            success = await client.async_send_command(cmd, data, alias)
+            success = await self.coordinator.async_send_command(cmd, data)
             if not success:
                 _LOGGER.error("Failed to send CMD %d for %s", cmd, self.entity_description.key)
                 return

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING
@@ -27,6 +28,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         self._address: str = config_entry.data[CONF_ADDRESS]
         self._alias: str = config_entry.data[CONF_MODEL]
         self._name: str = config_entry.data[CONF_NAME]
+        self._ble_lock = asyncio.Lock()
 
         super().__init__(
             hass,
@@ -35,17 +37,41 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             update_interval=timedelta(seconds=POLL_INTERVAL),
         )
 
-    async def _async_update_data(self) -> PetkitFountainData:
-        """Fetch the latest data from the fountain."""
+    def _get_ble_device(self) -> PetkitBleClient | None:
+        """Return a BLE client for the fountain, or None if not reachable."""
         ble_device = async_ble_device_from_address(self.hass, self._address, connectable=True)
         if ble_device is None:
-            raise UpdateFailed(f"Petkit fountain {self._name} ({self._address}) not reachable via Bluetooth")
+            return None
+        return PetkitBleClient(ble_device)
 
-        client = PetkitBleClient(ble_device)
-        try:
-            data = await client.async_poll(self._alias)
-        except Exception as exc:
-            raise UpdateFailed(f"Error communicating with {self._name}: {exc}") from exc
+    async def _async_update_data(self) -> PetkitFountainData:
+        """Fetch the latest data from the fountain."""
+        async with self._ble_lock:
+            client = self._get_ble_device()
+            if client is None:
+                raise UpdateFailed(f"Petkit fountain {self._name} ({self._address}) not reachable via Bluetooth")
+            try:
+                data = await client.async_poll(self._alias)
+            except Exception as exc:
+                raise UpdateFailed(f"Error communicating with {self._name}: {exc}") from exc
 
         _LOGGER.debug("Polled %s: power=%s mode=%s", self._name, data.power_status, data.mode)
         return data
+
+    async def async_send_command(self, cmd: int, data: list[int]) -> bool:
+        """Send a single BLE command, serialised with the poll lock.
+
+        Returns True on success, False if the device was not reachable or the
+        command failed.
+        """
+        async with self._ble_lock:
+            client = self._get_ble_device()
+            if client is None:
+                _LOGGER.warning(
+                    "Cannot send CMD %d: %s (%s) not reachable via Bluetooth",
+                    cmd,
+                    self._name,
+                    self._address,
+                )
+                return False
+            return await client.async_send_command(cmd, data, self._alias)

--- a/custom_components/petkit_ble/switch.py
+++ b/custom_components/petkit_ble/switch.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import async_ble_device_from_address
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .ble_client import PetkitBleClient
-from .const import CMD_SET_POWER_MODE, CONF_ADDRESS, CONF_MODEL
+from .const import CMD_SET_POWER_MODE
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
 
@@ -57,18 +55,12 @@ class PetkitPowerSwitch(PetkitBleEntity, SwitchEntity):
 
     async def _set_power(self, power_state: int) -> None:
         """Send CMD 220 with the desired power state, keeping the current mode."""
-        address: str = self.coordinator.config_entry.data[CONF_ADDRESS]
-        alias: str = self.coordinator.config_entry.data[CONF_MODEL]
-        mode = self.coordinator.data.mode if self.coordinator.data else 1
+        # Use the last known mode; default to 1 (normal) if data is absent or mode is invalid.
+        raw_mode = self.coordinator.data.mode if self.coordinator.data else 1
+        mode = raw_mode if raw_mode in (1, 2) else 1
 
-        ble_device = async_ble_device_from_address(self.coordinator.hass, address, connectable=True)
-        if ble_device is None:
-            _LOGGER.warning("Cannot set power: device %s not found", address)
-            return
-
-        client = PetkitBleClient(ble_device)
-        success = await client.async_send_command(CMD_SET_POWER_MODE, [power_state, mode], alias)
+        success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, [power_state, mode])
         if success:
             await self.coordinator.async_request_refresh()
         else:
-            _LOGGER.error("Failed to set power state to %d for %s", power_state, address)
+            _LOGGER.error("Failed to set power state to %d", power_state)


### PR DESCRIPTION
## Problem
The fountain could be turned off but not back on. Two root causes:

### 1. BLE race condition (most likely culprit)
The coordinator polls every 60 seconds via BLE, and the switch/button entities were each creating **independent BLE clients** that connected without coordination. When a poll was in progress while the user pressed a button, both BLE connections raced — since the CTW3 only allows one GATT connection at a time, one would fail silently.

### 2. Invalid mode value
When the device reports \mode=0\ (possible when off), the turn-on command was sent as \[1, 0]\. Mode 0 is invalid — the device only understands 1 (normal) and 2 (smart). This may have caused the device to silently ignore the command.

## Fix

- **\coordinator.py\**: Added \syncio.Lock\ (\_ble_lock\) — all BLE access (poll + commands) acquires this lock, preventing concurrent connections. Added \sync_send_command()\ method so entities route through the coordinator.
- **\switch.py\**: Uses \coordinator.async_send_command()\ instead of creating its own \PetkitBleClient\. Validates \mode\ is 1 or 2 before use.
- **\utton.py\**: Same pattern — all button presses go through \coordinator.async_send_command()\. Mode validation added to pump on/off helpers.