### PR TITLE
feat: show pump runtime as human-readable duration

### DIFF
--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -31,6 +31,18 @@ from .entity import PetkitBleEntity
 _LOGGER = logging.getLogger(__name__)
 
 
+def _format_seconds(total_seconds: int) -> str:
+    """Format a duration in seconds as a human-readable string (e.g. '5d 14h 23m 12s')."""
+    days, remainder = divmod(int(total_seconds), 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if days > 0:
+        return f"{days}d {hours}h {minutes}m {seconds}s"
+    if hours > 0:
+        return f"{hours}h {minutes}m {seconds}s"
+    return f"{minutes}m {seconds}s"
+
+
 @dataclass(frozen=True, kw_only=True)
 class PetkitSensorEntityDescription(SensorEntityDescription):
     """Sensor description with value extractor and optional availability check."""
@@ -51,18 +63,14 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
     PetkitSensorEntityDescription(
         key="pump_runtime_today",
         translation_key="pump_runtime_today",
-        native_unit_of_measurement=UnitOfTime.MINUTES,
-        device_class=SensorDeviceClass.DURATION,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda d: round(d.pump_runtime_today / 60, 1),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: _format_seconds(d.pump_runtime_today),
     ),
     PetkitSensorEntityDescription(
         key="pump_runtime",
         translation_key="pump_runtime",
-        native_unit_of_measurement=UnitOfTime.SECONDS,
-        device_class=SensorDeviceClass.DURATION,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda d: d.pump_runtime,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: _format_seconds(d.pump_runtime),
     ),
     PetkitSensorEntityDescription(
         key="battery_percent",


### PR DESCRIPTION
## Change
Instead of showing raw seconds, both runtime sensors now display a formatted string:

| Sensor | Before | After |
|--------|--------|-------|
| Total Pump Runtime | \500342 s\ | \5d 18h 59m 2s\ |
| Pump Runtime Today | \138.5 min\ | \2h 18m 30s\ |

## Format logic
- \_format_seconds()\ helper: \Xd Yh Zm Zs\ → omits leading zero groups
- e.g. 0 days → \2h 15m 3s\, 0 hours → \45m 12s\

## Trade-off
String sensors cannot be used for numeric statistics/graphing. The sensors are reclassified as \EntityCategory.DIAGNOSTIC\ with no \state_class\. The \water_purified_today\ and \nergy_today\ sensors still provide graphable statistics derived from the same underlying data.