### PR TITLE
fix: remove redundant pump_on/pump_off buttons

### DIFF
--- a/custom_components/petkit_ble/button.py
+++ b/custom_components/petkit_ble/button.py
@@ -10,7 +10,7 @@ from homeassistant.components.button import ButtonEntity, ButtonEntityDescriptio
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CMD_RESET_FILTER, CMD_SET_POWER_MODE
+from .const import CMD_RESET_FILTER
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
 
@@ -28,33 +28,11 @@ def _reset_filter_cmds(_coordinator: PetkitBleCoordinator) -> list[tuple[int, li
     return [(CMD_RESET_FILTER, [0])]
 
 
-def _pump_on_cmds(coordinator: PetkitBleCoordinator) -> list[tuple[int, list[int]]]:
-    raw_mode = coordinator.data.mode if coordinator.data else 1
-    mode = raw_mode if raw_mode in (1, 2) else 1
-    return [(CMD_SET_POWER_MODE, [1, mode])]
-
-
-def _pump_off_cmds(coordinator: PetkitBleCoordinator) -> list[tuple[int, list[int]]]:
-    raw_mode = coordinator.data.mode if coordinator.data else 1
-    mode = raw_mode if raw_mode in (1, 2) else 1
-    return [(CMD_SET_POWER_MODE, [0, mode])]
-
-
 BUTTON_DESCRIPTIONS: tuple[PetkitButtonDescription, ...] = (
     PetkitButtonDescription(
         key="reset_filter",
         translation_key="reset_filter",
         press_fn=_reset_filter_cmds,
-    ),
-    PetkitButtonDescription(
-        key="pump_on",
-        translation_key="pump_on",
-        press_fn=_pump_on_cmds,
-    ),
-    PetkitButtonDescription(
-        key="pump_off",
-        translation_key="pump_off",
-        press_fn=_pump_off_cmds,
     ),
 )
 

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -61,9 +61,7 @@
       "low_battery": {"name": "Low Battery"}
     },
     "button": {
-      "reset_filter": {"name": "Reset Filter"},
-      "pump_on": {"name": "Pump On"},
-      "pump_off": {"name": "Pump Off"}
+      "reset_filter": {"name": "Reset Filter"}
     },
     "switch": {
       "power": {"name": "Power"}

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -61,9 +61,7 @@
       "low_battery": {"name": "Batterij bijna leeg"}
     },
     "button": {
-      "reset_filter": {"name": "Filter resetten"},
-      "pump_on": {"name": "Pomp aan"},
-      "pump_off": {"name": "Pomp uit"}
+      "reset_filter": {"name": "Filter resetten"}
     },
     "switch": {
       "power": {"name": "Aan/Uit"}

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -61,9 +61,7 @@
       "low_battery": {"name": "Низький заряд батареї"}
     },
     "button": {
-      "reset_filter": {"name": "Скинути фільтр"},
-      "pump_on": {"name": "Насос увімкнути"},
-      "pump_off": {"name": "Насос вимкнути"}
+      "reset_filter": {"name": "Скинути фільтр"}
     },
     "switch": {
       "power": {"name": "Живлення"}


### PR DESCRIPTION
The \pump_on\ and \pump_off\ buttons sent the exact same \CMD 220\ command as the power switch. This caused confusing behaviour: pressing **Pomp uit** also turned off the **Aan/Uit** switch.

**Root cause:** Both buttons and the switch use \CMD_SET_POWER_MODE\ (220) with \[power, mode]\. There is no separate protocol command to pause/resume the pump independently from power.

**Fix:** Remove \pump_on\ / \pump_off\ buttons. The **Aan/Uit** power switch is the correct single control for turning the fountain on or off.