### PR TITLE
feat: add mode select entity and suspend_status binary sensor

### DIFF
--- a/custom_components/petkit_ble/__init__.py
+++ b/custom_components/petkit_ble/__init__.py
@@ -19,6 +19,7 @@ PLATFORMS = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.SELECT,
     Platform.SWITCH,
 ]
 

--- a/custom_components/petkit_ble/binary_sensor.py
+++ b/custom_components/petkit_ble/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -79,6 +80,13 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PetkitBinarySensorDescription, ...] = (
         translation_key="low_battery",
         device_class=BinarySensorDeviceClass.BATTERY,
         value_fn=lambda d: bool(d.low_battery),
+        available_fn=lambda d: d.is_ctw3,
+    ),
+    PetkitBinarySensorDescription(
+        key="suspended",
+        translation_key="suspended",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: bool(d.suspend_status),
         available_fn=lambda d: d.is_ctw3,
     ),
 )

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -1,0 +1,64 @@
+"""Select platform for Petkit BLE (operation mode)."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CMD_SET_POWER_MODE
+from .coordinator import PetkitBleCoordinator
+from .entity import PetkitBleEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Map HA option strings → Petkit mode integers
+_MODE_TO_INT: dict[str, int] = {"normal": 1, "smart": 2}
+_INT_TO_MODE: dict[int, str] = {v: k for k, v in _MODE_TO_INT.items()}
+
+MODE_SELECT_DESCRIPTION = SelectEntityDescription(
+    key="mode",
+    translation_key="mode",
+    options=["normal", "smart"],
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Petkit BLE select entities from a config entry."""
+    coordinator: PetkitBleCoordinator = config_entry.runtime_data
+    async_add_entities([PetkitModeSelect(coordinator)])
+
+
+class PetkitModeSelect(PetkitBleEntity, SelectEntity):
+    """Select entity to choose between Normal and Smart pump mode."""
+
+    def __init__(self, coordinator: PetkitBleCoordinator) -> None:
+        """Initialise the mode select."""
+        super().__init__(coordinator, MODE_SELECT_DESCRIPTION.key)
+        self.entity_description = MODE_SELECT_DESCRIPTION
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current mode as an option string."""
+        if self.coordinator.data is None:
+            return None
+        return _INT_TO_MODE.get(self.coordinator.data.mode, "normal")
+
+    async def async_select_option(self, option: str) -> None:
+        """Send CMD 220 to change mode while preserving the current power state."""
+        mode_int = _MODE_TO_INT[option]
+        # Keep the current power state; default to 1 (on) if unknown.
+        raw_power = self.coordinator.data.power_status if self.coordinator.data else 1
+        power = raw_power if raw_power in (0, 1) else 1
+
+        success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, [power, mode_int])
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error("Failed to set mode to %s", option)

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -58,10 +58,20 @@
       "dnd_active": {"name": "Do Not Disturb"},
       "pet_detected": {"name": "Pet Drinking"},
       "on_ac_power": {"name": "AC Power"},
-      "low_battery": {"name": "Low Battery"}
+      "low_battery": {"name": "Low Battery"},
+      "suspended": {"name": "Pump Suspended"}
     },
     "button": {
       "reset_filter": {"name": "Reset Filter"}
+    },
+    "select": {
+      "mode": {
+        "name": "Mode",
+        "state": {
+          "normal": "Normal",
+          "smart": "Smart"
+        }
+      }
     },
     "switch": {
       "power": {"name": "Power"}

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -58,10 +58,20 @@
       "dnd_active": {"name": "Niet storen"},
       "pet_detected": {"name": "Huisdier drinkt"},
       "on_ac_power": {"name": "Netstroom"},
-      "low_battery": {"name": "Batterij bijna leeg"}
+      "low_battery": {"name": "Batterij bijna leeg"},
+      "suspended": {"name": "Pomp gepauzeerd"}
     },
     "button": {
       "reset_filter": {"name": "Filter resetten"}
+    },
+    "select": {
+      "mode": {
+        "name": "Modus",
+        "state": {
+          "normal": "Normaal",
+          "smart": "Smart"
+        }
+      }
     },
     "switch": {
       "power": {"name": "Aan/Uit"}

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -58,10 +58,20 @@
       "dnd_active": {"name": "Не турбувати"},
       "pet_detected": {"name": "Тварина п'є"},
       "on_ac_power": {"name": "Мережеве живлення"},
-      "low_battery": {"name": "Низький заряд батареї"}
+      "low_battery": {"name": "Низький заряд батареї"},
+      "suspended": {"name": "Насос призупинено"}
     },
     "button": {
       "reset_filter": {"name": "Скинути фільтр"}
+    },
+    "select": {
+      "mode": {
+        "name": "Режим",
+        "state": {
+          "normal": "Нормальний",
+          "smart": "Смарт"
+        }
+      }
     },
     "switch": {
       "power": {"name": "Живлення"}


### PR DESCRIPTION
Two new entities for the Petkit BLE integration.

**Mode select (Normal / Smart)**
- New \select.py\ platform with a \Mode\ select entity
- Options: **Normal** (mode=1) and **Smart** (mode=2)
- Sends CMD 220 \[current_power, mode]\ — never changes the power state
- Clearly separates mode control from power on/off (the Aan/Uit switch)

**Pump Suspended sensor (CTW3 only)**
- New diagnostic binary sensor that exposes \suspend_status\ (byte 1 of CMD 210 response)
- Read-only — reflects whether the device has paused the pump internally
- Only available on CTW3 devices (returns unavailable on other models)