### PR TITLE
fix: CTW3 mode payload + pump runtime als seconden

### DIFF
--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -61,10 +61,7 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
         # state response has suspend_status at byte[1] and mode at byte[2]. Generic
         # devices use [power, mode] (2 bytes, mode at byte[1]).
         data = self.coordinator.data
-        if data is not None and data.is_ctw3:
-            payload = [power, 0, mode_int]
-        else:
-            payload = [power, mode_int]
+        payload = [power, 0, mode_int] if data is not None and data.is_ctw3 else [power, mode_int]
 
         success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, payload)
         if success:

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -57,7 +57,16 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
         raw_power = self.coordinator.data.power_status if self.coordinator.data else 1
         power = raw_power if raw_power in (0, 1) else 1
 
-        success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, [power, mode_int])
+        # CTW3 CMD 220 uses a 3-byte payload [power, suspend_status, mode] because its
+        # state response has suspend_status at byte[1] and mode at byte[2]. Generic
+        # devices use [power, mode] (2 bytes, mode at byte[1]).
+        data = self.coordinator.data
+        if data is not None and data.is_ctw3:
+            payload = [power, 0, mode_int]
+        else:
+            payload = [power, mode_int]
+
+        success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, payload)
         if success:
             await self.coordinator.async_request_refresh()
         else:

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -31,7 +31,6 @@ from .entity import PetkitBleEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-
 @dataclass(frozen=True, kw_only=True)
 class PetkitSensorEntityDescription(SensorEntityDescription):
     """Sensor description with value extractor and optional availability check."""

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -31,17 +31,6 @@ from .entity import PetkitBleEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-def _format_seconds(total_seconds: int) -> str:
-    """Format a duration in seconds as a human-readable string (e.g. '5d 14h 23m 12s')."""
-    days, remainder = divmod(int(total_seconds), 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    if days > 0:
-        return f"{days}d {hours}h {minutes}m {seconds}s"
-    if hours > 0:
-        return f"{hours}h {minutes}m {seconds}s"
-    return f"{minutes}m {seconds}s"
-
 
 @dataclass(frozen=True, kw_only=True)
 class PetkitSensorEntityDescription(SensorEntityDescription):
@@ -64,13 +53,19 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         key="pump_runtime_today",
         translation_key="pump_runtime_today",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda d: _format_seconds(d.pump_runtime_today),
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda d: d.pump_runtime_today,
     ),
     PetkitSensorEntityDescription(
         key="pump_runtime",
         translation_key="pump_runtime",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda d: _format_seconds(d.pump_runtime),
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda d: d.pump_runtime,
     ),
     PetkitSensorEntityDescription(
         key="battery_percent",

--- a/custom_components/petkit_ble/switch.py
+++ b/custom_components/petkit_ble/switch.py
@@ -63,10 +63,7 @@ class PetkitPowerSwitch(PetkitBleEntity, SwitchEntity):
         # state response has suspend_status at byte[1] and mode at byte[2]. Generic
         # devices use [power, mode] (2 bytes, mode at byte[1]).
         data = self.coordinator.data
-        if data is not None and data.is_ctw3:
-            payload = [power_state, 0, mode]
-        else:
-            payload = [power_state, mode]
+        payload = [power_state, 0, mode] if data is not None and data.is_ctw3 else [power_state, mode]
 
         success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, payload)
         if success:

--- a/custom_components/petkit_ble/switch.py
+++ b/custom_components/petkit_ble/switch.py
@@ -59,7 +59,16 @@ class PetkitPowerSwitch(PetkitBleEntity, SwitchEntity):
         raw_mode = self.coordinator.data.mode if self.coordinator.data else 1
         mode = raw_mode if raw_mode in (1, 2) else 1
 
-        success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, [power_state, mode])
+        # CTW3 CMD 220 uses a 3-byte payload [power, suspend_status, mode] because its
+        # state response has suspend_status at byte[1] and mode at byte[2]. Generic
+        # devices use [power, mode] (2 bytes, mode at byte[1]).
+        data = self.coordinator.data
+        if data is not None and data.is_ctw3:
+            payload = [power_state, 0, mode]
+        else:
+            payload = [power_state, mode]
+
+        success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, payload)
         if success:
             await self.coordinator.async_request_refresh()
         else:


### PR DESCRIPTION
## Wijzigingen

### fix: pump runtime sensoren terug naar numerieke seconden
- Verwijder `_format_seconds` hulpfunctie uit `sensor.py`
- `pump_runtime` en `pump_runtime_today` geven nu raw `int` in seconden terug
- `native_unit_of_measurement=UnitOfTime.SECONDS`, `device_class=SensorDeviceClass.DURATION`

### fix: CTW3 CMD 220 byte-layout (mode gaat niet meer uit)
- CTW3 CMD 210 response heeft 3 bytes: `[power, suspend_status, mode]`
- Eerder stuurden `select.py` en `switch.py` slechts 2 bytes `[power, mode]`
- Dit zette `mode_int` op de `suspend_status` byte en het apparaat zette mode op 0 (uit)
- Fix: CTW3 stuurt nu `[power, 0, mode]`; overige devices blijven `[power, mode]`