### PR TITLE
feat: persist BLE auth secret per device for security

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -274,10 +274,8 @@ class PetkitBleClient:
             # First-time initialisation: fetch device ID and generate a random secret
             payload_213 = await self._send_and_wait(CMD_GET_DEVICE_INFO, FRAME_TYPE_SEND, [])
             if payload_213 is None or len(payload_213) < 8:
-                raise RuntimeError(
-                    "CMD 213 failed or response too short (got %d bytes)"
-                    % (len(payload_213) if payload_213 is not None else 0)
-                )
+                byte_count = len(payload_213) if payload_213 is not None else 0
+                raise RuntimeError(f"CMD 213 failed or response too short (got {byte_count} bytes)")
             # Convert device_id bytes to big-endian for CMD 73 payload
             device_id_be = struct.pack(">q", int.from_bytes(payload_213[:8], "little"))
             new_secret = secrets.token_bytes(8)
@@ -295,9 +293,8 @@ class PetkitBleClient:
         payload_86 = await self._send_and_wait(CMD_AUTH_VERIFY, FRAME_TYPE_SEND, list(auth_secret))
         await asyncio.sleep(AUTH_STEP_DELAY)
         if payload_86 is None or len(payload_86) == 0 or payload_86[0] != 1:
-            raise RuntimeError(
-                "Authentication failed (CMD 86 response: %s)" % (payload_86.hex() if payload_86 else "None")
-            )
+            resp_hex = payload_86.hex() if payload_86 else "None"
+            raise RuntimeError(f"Authentication failed (CMD 86 response: {resp_hex})")
 
         self.used_secret = auth_secret
 

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import math
+import secrets
 import struct
 import time
 from dataclasses import dataclass
@@ -39,7 +40,6 @@ from .const import (
     FRAME_TYPE_SEND,
     PETKIT_EPOCH_OFFSET,
     POWER_COEFF_W,
-    ZERO_DEVICE_ID_MODELS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -140,6 +140,7 @@ class PetkitBleClient:
         self._rx_event: asyncio.Event = asyncio.Event()
         self._last_response: bytes | None = None
         self._seq: int = 0
+        self.used_secret: bytes | None = None
 
     # ------------------------------------------------------------------
     # Frame encode / decode
@@ -260,54 +261,47 @@ class PetkitBleClient:
     # Authentication sequence
     # ------------------------------------------------------------------
 
-    async def _authenticate(self, alias: str) -> None:
-        """Run the full 5-step Petkit authentication sequence."""
-        # Step 1: CMD 213 — get device id & serial
-        payload_213 = await self._send_and_wait(CMD_GET_DEVICE_INFO, FRAME_TYPE_SEND, [0, 0])
-        if payload_213 is None or len(payload_213) < 8:
-            _LOGGER.error(
-                "CMD 213 failed or response too short (got %d bytes): %s",
-                len(payload_213) if payload_213 is not None else 0,
-                payload_213.hex() if payload_213 is not None else "None",
-            )
-            raise RuntimeError("CMD 213 failed or response too short")
+    async def _authenticate(self, alias: str, secret: bytes | None = None) -> None:
+        """Run the Petkit authentication sequence.
 
-        device_id_bytes = list(payload_213[2:8])
-        # serial = payload_213[8:23]  # available if needed
+        On first connection (secret=None), fetches the device ID, generates a random
+        8-byte secret, initialises the device with CMD 73, then verifies with CMD 86.
+        The generated secret is stored in self.used_secret for the coordinator to persist.
 
-        # Step 2: Compute secret
-        # CTW3 always uses all-zero device_id for secret computation
-        secret_source = [0] * 6 if alias in ZERO_DEVICE_ID_MODELS else device_id_bytes
+        On subsequent connections, verifies directly with CMD 86 using the stored secret.
+        """
+        if secret is None:
+            # First-time initialisation: fetch device ID and generate a random secret
+            payload_213 = await self._send_and_wait(CMD_GET_DEVICE_INFO, FRAME_TYPE_SEND, [])
+            if payload_213 is None or len(payload_213) < 8:
+                raise RuntimeError(
+                    "CMD 213 failed or response too short (got %d bytes)"
+                    % (len(payload_213) if payload_213 is not None else 0)
+                )
+            # Convert device_id bytes to big-endian for CMD 73 payload
+            device_id_be = struct.pack(">q", int.from_bytes(payload_213[:8], "little"))
+            new_secret = secrets.token_bytes(8)
 
-        secret = list(reversed(secret_source))
-        if secret[-1] == 0 and secret[-2] == 0:
-            secret[-2] = 13
-            secret[-1] = 37
-        # Pad left to 8 bytes
-        secret = [*([0] * (8 - len(secret))), *secret]
+            await asyncio.sleep(AUTH_STEP_DELAY)
+            await self._send_and_wait(CMD_AUTH_INIT, FRAME_TYPE_SEND, list(device_id_be) + list(new_secret))
+            await asyncio.sleep(AUTH_STEP_DELAY)
 
-        # device_id padded to 8 bytes (left-pad with zeros)
-        device_id_padded = [*([0] * (8 - len(device_id_bytes))), *device_id_bytes]
+            auth_secret = new_secret
+            _LOGGER.debug("First-time device initialisation complete for %s", alias)
+        else:
+            auth_secret = secret
 
-        await asyncio.sleep(AUTH_STEP_DELAY)
-
-        # Step 3: CMD 73
-        await self._send_and_wait(
-            CMD_AUTH_INIT,
-            FRAME_TYPE_SEND,
-            [0, 0, *device_id_padded, *secret],
-        )
-        await asyncio.sleep(AUTH_STEP_DELAY)
-
-        # Step 4: CMD 86 — verify auth; response[0]==1 means success
-        payload_86 = await self._send_and_wait(CMD_AUTH_VERIFY, FRAME_TYPE_SEND, [0, 0, *secret])
+        # CMD 86 — verify secret; response[0]==1 means success
+        payload_86 = await self._send_and_wait(CMD_AUTH_VERIFY, FRAME_TYPE_SEND, list(auth_secret))
         await asyncio.sleep(AUTH_STEP_DELAY)
         if payload_86 is None or len(payload_86) == 0 or payload_86[0] != 1:
             raise RuntimeError(
                 "Authentication failed (CMD 86 response: %s)" % (payload_86.hex() if payload_86 else "None")
             )
 
-        # Step 5: CMD 84 — set device time
+        self.used_secret = auth_secret
+
+        # CMD 84 — set device time
         sec = int(time.time()) - PETKIT_EPOCH_OFFSET
         time_bytes = [
             0,
@@ -403,15 +397,16 @@ class PetkitBleClient:
     # Public API
     # ------------------------------------------------------------------
 
-    async def async_poll(self, alias: str) -> PetkitFountainData:
+    async def async_poll(self, alias: str, secret: bytes | None = None) -> PetkitFountainData:
         """Connect, authenticate, poll all state commands, disconnect.
 
         Returns a fully-populated PetkitFountainData instance.
+        The generated or used secret is stored in self.used_secret after success.
         """
         data = PetkitFountainData(alias=alias)
         try:
             await self._connect()
-            await self._authenticate(alias)
+            await self._authenticate(alias, secret)
 
             # CMD 200 — firmware version: byte[0]=hardware, byte[1]=firmware
             payload_200 = await self._send_and_wait(CMD_GET_FIRMWARE, FRAME_TYPE_SEND, [])
@@ -420,7 +415,7 @@ class PetkitBleClient:
                 _LOGGER.debug("CMD 200 firmware payload: %s → %s", payload_200.hex(), data.firmware)
 
             # CMD 210 — device state
-            payload_210 = await self._send_and_wait(CMD_GET_STATE, FRAME_TYPE_SEND, [0, 0])
+            payload_210 = await self._send_and_wait(CMD_GET_STATE, FRAME_TYPE_SEND, [])
             if payload_210 is not None:
                 if alias in CTW3_ALIASES:
                     self._parse_state_ctw3(data, payload_210)
@@ -428,7 +423,7 @@ class PetkitBleClient:
                     self._parse_state_generic(data, payload_210)
 
             # CMD 211 — device config
-            payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [0, 0])
+            payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [])
             if payload_211 is not None:
                 if alias in CTW3_ALIASES:
                     self._parse_config_ctw3(data, payload_211)
@@ -436,7 +431,7 @@ class PetkitBleClient:
                     self._parse_config_generic(data, payload_211)
 
             # CMD 66 — battery (mainly for non-CTW3)
-            payload_66 = await self._send_and_wait(CMD_GET_BATTERY, FRAME_TYPE_SEND, [0, 0])
+            payload_66 = await self._send_and_wait(CMD_GET_BATTERY, FRAME_TYPE_SEND, [])
             if payload_66 is not None and len(payload_66) >= 3:
                 data.battery_voltage_mv_66 = payload_66[0] * 256 + (payload_66[1] & 0xFF)
                 data.battery_percent_66 = payload_66[2]
@@ -451,6 +446,7 @@ class PetkitBleClient:
         cmd: int,
         data: list[int],
         alias: str,
+        secret: bytes | None = None,
     ) -> bool:
         """Connect, authenticate, send a single command, disconnect.
 
@@ -458,7 +454,7 @@ class PetkitBleClient:
         """
         try:
             await self._connect()
-            await self._authenticate(alias)
+            await self._authenticate(alias, secret)
             await self._send_and_wait(cmd, FRAME_TYPE_SEND, data)
         except Exception:
             _LOGGER.exception("Error sending CMD %d", cmd)

--- a/custom_components/petkit_ble/const.py
+++ b/custom_components/petkit_ble/const.py
@@ -32,6 +32,7 @@ CMD_RESET_FILTER = 222
 CONF_ADDRESS = "address"
 CONF_NAME = "name"
 CONF_MODEL = "model"
+CONF_DEVICE_SECRET = "device_secret"
 
 # Device aliases derived from BLE name
 ALIAS_CTW3 = "CTW3"
@@ -51,9 +52,6 @@ PETKIT_NAME_PREFIXES = (
 
 # Aliases that use the CTW3 26-byte state format
 CTW3_ALIASES = {ALIAS_CTW3}
-
-# Models that use all-zero device_id for auth secret computation
-ZERO_DEVICE_ID_MODELS = {ALIAS_CTW3}
 
 # Poll interval in seconds
 POLL_INTERVAL = 60

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from .ble_client import PetkitBleClient, PetkitFountainData
-from .const import CONF_ADDRESS, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
+from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,11 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         self._address: str = config_entry.data[CONF_ADDRESS]
         self._alias: str = config_entry.data[CONF_MODEL]
         self._name: str = config_entry.data[CONF_NAME]
+        self._config_entry = config_entry
         self._ble_lock = asyncio.Lock()
+
+        secret_hex = config_entry.data.get(CONF_DEVICE_SECRET)
+        self._secret: bytes | None = bytes.fromhex(secret_hex) if secret_hex else None
 
         super().__init__(
             hass,
@@ -51,9 +55,16 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             if client is None:
                 raise UpdateFailed(f"Petkit fountain {self._name} ({self._address}) not reachable via Bluetooth")
             try:
-                data = await client.async_poll(self._alias)
+                data = await client.async_poll(self._alias, self._secret)
             except Exception as exc:
                 raise UpdateFailed(f"Error communicating with {self._name}: {exc}") from exc
+
+            # Persist the secret after first-time device initialisation
+            if self._secret is None and client.used_secret is not None:
+                self._secret = client.used_secret
+                new_data = {**self._config_entry.data, CONF_DEVICE_SECRET: self._secret.hex()}
+                self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+                _LOGGER.info("Device secret saved for %s (%s)", self._name, self._address)
 
         _LOGGER.debug(
             "Polled %s: power=%s mode=%s firmware=%s", self._name, data.power_status, data.mode, data.firmware
@@ -82,4 +93,4 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
                     self._address,
                 )
                 return False
-            return await client.async_send_command(cmd, data, self._alias)
+            return await client.async_send_command(cmd, data, self._alias, self._secret)


### PR DESCRIPTION
## Summary

On first connection, generate a random 8-byte secret, initialise the device via CMD 73, verify with CMD 86, and save the secret in the HA config entry. Subsequent connections authenticate directly with CMD 86 using the stored secret.

## Background

Analysis of the full [petkit-ble-reverse-engineering](https://github.com/mr-ransel/petkit-ble-reverse-engineering) repository revealed that:
- CMD 73 is for **one-time** device initialisation, not every connection
- Our old code called CMD 73 on **every** connection (unnecessary permanent write to device)
- Our CMD 86 sent `[0, 0, *secret]` — the `[0, 0]` prefix caused the device to read 8 zero bytes as the effective secret, so auth worked **by accident** with a zero secret

## Changes

### `ble_client.py`
- `_authenticate(alias, secret=None)`: if `secret is None` (first time), generates a random 8-byte secret, calls CMD 73 to initialise device, then verifies with CMD 86; if secret provided, verifies directly with CMD 86
- Exposes `used_secret` attribute for coordinator to persist
- Read commands (CMD 210, 211, 66) now use empty payload `[]` instead of `[0, 0]`
- Removes incorrect `[0, 0]` prefix from all auth commands

### `coordinator.py`
- Loads stored secret from `entry.data["device_secret"]` on startup
- Passes secret to `async_poll` and `async_send_command`
- Saves new secret to config entry after first-time device initialisation

### `const.py`
- Adds `CONF_DEVICE_SECRET = "device_secret"`
- Removes `ZERO_DEVICE_ID_MODELS` (no longer needed)

## Migration for existing users

Existing devices had CMD 73 called with a malformed payload, effectively setting a zero secret. After this update, the first poll will re-initialise the device with a proper random secret, which is then saved. No manual action required.
