### PR TITLE
feat: hardware version sensor, protocol docs, Copilot skill

### DIFF
--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -1,0 +1,117 @@
+---
+applyTo: "custom_components/petkit_ble/**"
+---
+
+# ha-petkit BLE Integration — Copilot Skill
+
+Specialized context for the `petkit_ble` Home Assistant custom integration.
+Apply this knowledge when reading, writing, or reviewing code in `custom_components/petkit_ble/`.
+
+## Project Essentials
+
+- **Domain:** `petkit_ble`
+- **Protocol:** Bluetooth Low Energy (BLE), Petkit proprietary framing
+- **HA minimum:** 2024.1 — uses `entry.runtime_data`, `CoordinatorEntity`, `async_ble_device_from_address`
+- **Python:** 3.12+, `from __future__ import annotations` in every module, `collections.abc.Callable`
+- **Linter:** ruff — run `uv run ruff check custom_components/` before committing
+- **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
+
+## BLE Frame Format
+
+```
+[FA FC FD, cmd, type, seq, len_lo, 0x00, ...payload..., FB]
+```
+
+- `FRAME_TYPE_SEND = 0x01` for requests
+- All const values (UUIDs, CMD IDs) live in `const.py`
+
+## Authentication Sequence
+
+1. **First connection** (no stored secret): CMD 213 → CMD 73 (device_id_be + random_secret) → CMD 86 (secret) → CMD 84 (time)
+2. **Subsequent connections**: CMD 86 (stored secret) → CMD 84 (time)
+3. Secret persisted in `entry.data["device_secret"]` (hex string)
+4. `client.used_secret` is set after successful auth; coordinator detects first-time init and saves
+
+## Device Aliases & Detection
+
+```
+W4XUVC → W4X UVC   (check more-specific first)
+W4X    → W4X
+W5C    → W5C
+W5N    → W5N
+W5     → W5
+CTW3   → CTW3
+CTW2   → CTW2
+```
+
+`CTW3_ALIASES` constant holds the set of CTW3 variant names.
+
+## Key Commands
+
+| CMD | Constant | Direction | Notes |
+|-----|----------|-----------|-------|
+| 213 | `CMD_GET_DEVICE_INFO` | Read | Device ID + serial; empty payload |
+| 73  | `CMD_AUTH_INIT` | Write | 16 bytes: device_id_be(8) + secret(8) |
+| 86  | `CMD_AUTH_VERIFY` | Write | 8 bytes secret; response[0]==1 = success |
+| 84  | `CMD_SET_TIME` | Write | Petkit epoch offset = 946684800 (2000-01-01) |
+| 200 | `CMD_GET_FIRMWARE` | Read | payload[0]=hardware_version, payload[1]=firmware |
+| 210 | `CMD_GET_STATE` | Read | Device state (all models) |
+| 211 | `CMD_GET_CONFIG` | Read | Settings — **NOT sent to CTW3** (device never responds) |
+| 66  | `CMD_GET_BATTERY` | Read | Battery voltage (non-CTW3) |
+| 220 | `CMD_SET_MODE` | Write | [mode, 0]: 0=off, 1=normal, 2=smart |
+| 222 | `CMD_RESET_FILTER` | Write | Empty payload; resets filter % to 100 |
+
+## State Payload Layouts
+
+**CMD 210 generic (W4/W5/CTW2) — 12+ bytes (big-endian):**
+```
+[0] powerStatus  [1] mode  [2] dnd  [3] warningBreakdown  [4] warningWaterMissing
+[5] warningFilter  [6-9] pumpRuntime(uint32)  [10] filterPercent  [11] runningStatus
+[12-15] pumpRuntimeToday(uint32, optional)  [16] smartTimeOn  [17] smartTimeOff
+```
+
+**CMD 210 CTW3 — 26+ bytes (big-endian):**
+```
+[0] powerStatus  [1] suspendStatus  [2] mode  [3] electricStatus  [4] dndState
+[5] warningBreakdown  [6] warningWaterMissing  [7] lowBattery  [8] warningFilter
+[9-12] pumpRuntime(uint32)  [13] filterPercent  [14] runningStatus
+[15-18] pumpRuntimeToday(uint32)  [19] detectStatus
+[20-21] supplyVoltageMv(int16)  [22-23] batteryVoltageMv(int16)
+[24] batteryPercent  [25] moduleStatus
+```
+
+## CTW3 Quirks
+
+- **CMD 211 is skipped** — CTW3 never responds; skipping saves 5s per poll
+- **CMD 230 (0xe6) unsolicited push** — CTW3 sends extended state pushes at any time; `_send_and_wait` discards mismatched cmd bytes via `asyncio.Queue`
+- **Auth uses `device_id_be` from CMD 213** — do NOT use `[0]*8` for CTW3 anymore (PR #17 fixed this)
+
+## Calculated Properties (on `PetkitFountainData`)
+
+- `filter_days_remaining` — depends on `mode`, `smart_time_on/off`, `filter_percent`
+- `water_purified_today_liters` — uses `FLOW_RATE_LPM` and `FLOW_DIVISOR` from `const.py`
+- `energy_today_kwh` — uses `POWER_COEFF_W` from `const.py`
+
+## Adding a New Sensor
+
+1. Add field to `PetkitFountainData` in `ble_client.py`
+2. Parse in the correct `_parse_state_*` or `_parse_config_*` method
+3. Add `PetkitSensorEntityDescription` entry to `SENSOR_DESCRIPTIONS` in `sensor.py`
+4. Add translation key to `strings.json` (source of truth)
+5. Mirror to `translations/en.json`, `translations/nl.json`, `translations/uk.json`
+
+## File Map
+
+```
+ble_client.py    — BLE protocol, frame encode/decode, auth, state parsers, PetkitFountainData
+coordinator.py   — DataUpdateCoordinator (60s), secret load/save, RSSI
+config_flow.py   — bluetooth auto-discovery + manual entry
+entity.py        — PetkitBleEntity base (CoordinatorEntity + DeviceInfo)
+sensor.py        — 10 diagnostic + measurement sensors
+binary_sensor.py — 9 binary sensors (pump, warnings, DND, pet, AC, battery)
+button.py        — reset filter, pump on/off
+switch.py        — power on/off
+select.py        — mode selection (normal/smart)
+const.py         — all constants: UUIDs, CMD IDs, aliases, flow rates, epoch offset
+strings.json     — source-of-truth translations (English)
+```

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -51,6 +51,7 @@ class PetkitFountainData:
 
     alias: str = ""
     firmware: str = ""
+    hardware_version: str = ""
     rssi: int | None = None
 
     # Power & mode (CMD 210)
@@ -405,11 +406,17 @@ class PetkitBleClient:
             await self._connect()
             await self._authenticate(alias, secret)
 
-            # CMD 200 — firmware version: byte[0]=hardware, byte[1]=firmware
+            # CMD 200 — firmware version: byte[0]=hardware revision, byte[1]=firmware version
             payload_200 = await self._send_and_wait(CMD_GET_FIRMWARE, FRAME_TYPE_SEND, [])
             if payload_200 is not None and len(payload_200) >= 2:
-                data.firmware = f"{payload_200[0]}.{payload_200[1]}"
-                _LOGGER.debug("CMD 200 firmware payload: %s → %s", payload_200.hex(), data.firmware)
+                data.hardware_version = str(payload_200[0])
+                data.firmware = str(payload_200[1])
+                _LOGGER.debug(
+                    "CMD 200 firmware payload: %s → hw=%s fw=%s",
+                    payload_200.hex(),
+                    data.hardware_version,
+                    data.firmware,
+                )
 
             # CMD 210 — device state
             payload_210 = await self._send_and_wait(CMD_GET_STATE, FRAME_TYPE_SEND, [])

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -121,6 +121,12 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         value_fn=lambda d: d.firmware or None,
     ),
     PetkitSensorEntityDescription(
+        key="hardware_version",
+        translation_key="hardware_version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: d.hardware_version or None,
+    ),
+    PetkitSensorEntityDescription(
         key="rssi",
         translation_key="rssi",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -48,6 +48,7 @@
       "energy_today": {"name": "Energy Today"},
       "filter_days_remaining": {"name": "Filter Days Remaining"},
       "firmware": {"name": "Firmware"},
+      "hardware_version": {"name": "Hardware Version"},
       "rssi": {"name": "Signal Strength"}
     },
     "binary_sensor": {

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -48,6 +48,7 @@
       "energy_today": {"name": "Energieverbruik vandaag"},
       "filter_days_remaining": {"name": "Resterende filterdagen"},
       "firmware": {"name": "Firmware"},
+      "hardware_version": {"name": "Hardwareversie"},
       "rssi": {"name": "Signaalsterkte"}
     },
     "binary_sensor": {

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -48,6 +48,7 @@
       "energy_today": {"name": "Споживання енергії сьогодні"},
       "filter_days_remaining": {"name": "Залишилось днів фільтра"},
       "firmware": {"name": "Прошивка"},
+      "hardware_version": {"name": "Версія апаратного забезпечення"},
       "rssi": {"name": "Рівень сигналу"}
     },
     "binary_sensor": {

--- a/docs/W5_BLE_PROTOCOL.md
+++ b/docs/W5_BLE_PROTOCOL.md
@@ -1,0 +1,299 @@
+# Petkit W5 / CTW2 BLE Protocol
+
+> **Source:** This document is reproduced from
+> [`mr-ransel/petkit-ble-reverse-engineering`](https://github.com/mr-ransel/petkit-ble-reverse-engineering/blob/main/W5_BLE_PROTOCOL.md)
+> by [@mr-ransel](https://github.com/mr-ransel), used here for reference.
+> All reverse-engineering credit goes to the original author.
+>
+> **ha-petkit notes** are appended at the bottom with findings from our own
+> CTW3 log analysis and implementation experience.
+
+---
+
+# PetKit Eversweet Solo 2 (W5/CTW2) BLE Protocol
+
+Reverse-engineered BLE protocol for the PetKit Eversweet Solo 2 wireless water fountain.
+
+**Target device:** PetKit Eversweet Solo 2 (wireless water fountain)
+**BLE advertisement name:** `Petkit_CTW2`
+
+## Device Family
+
+This protocol is shared across the W5 device family:
+
+| BLE Name | Product | typeCode |
+|---|---|---|
+| `Petkit_W5` | Eversweet (original) | 1 |
+| `Petkit_W5C` | Eversweet variant | 2 |
+| `Petkit_W5N` | Eversweet variant | 3 |
+| `Petkit_W4X` | Eversweet W4X | — |
+| `Petkit_W4XUVC` | Eversweet W4X UVC | — |
+| `Petkit_CTW2` | Eversweet Solo 2 (wireless) | — |
+
+All use the same GATT service, packet framing, and command set. Minor differences exist in extended features based on `typeCode` and firmware version.
+
+## GATT Service
+
+| UUID | Role |
+|---|---|
+| `0000aaa0-0000-1000-8000-00805f9b34fb` | Service |
+| `0000aaa2-0000-1000-8000-00805f9b34fb` | Write characteristic (commands to device) |
+| `0000aaa1-0000-1000-8000-00805f9b34fb` | Notify characteristic (responses from device) |
+
+## Packet Framing
+
+All BLE packets (both directions) use the same framing:
+
+```
+FA FC FD <cmd:1> <type:1> <seq:1> <len_lo:1> <len_hi:1> [data:N] FB
+```
+
+| Field | Size | Description |
+|---|---|---|
+| Header | 3 bytes | Always `FA FC FD` |
+| cmd | 1 byte | Command ID |
+| type | 1 byte | 1=Request, 2=Response, 3=Non-response request |
+| seq | 1 byte | Sequence number (0-255, wrapping) |
+| len | 2 bytes | Little-endian payload length |
+| data | N bytes | Payload (may be 0 bytes) |
+| Trailer | 1 byte | Always `FB` |
+
+## Connection & Authentication Flow
+
+### Normal (read-only, uninitialized device)
+
+1. **Connect** to GATT service
+2. **Subscribe** to notify characteristic (`0xAAA1`)
+3. **CMD 213** — Get device ID + serial number
+4. **CMD 86** — Verify with zero secret (8 null bytes). Works when deviceId == 0 (uninitialized)
+5. **CMD 84** — Time sync (required before reads)
+6. Read commands: CMD 200, CMD 210, CMD 211, CMD 66, CMD 215/216
+
+### Full initialization flow (as done by the official app)
+
+1. CMD 213 — Get device ID
+2. If deviceId == 0 (new device): app calls a cloud API to get a server-assigned deviceId + secret
+3. CMD 73 — Init device (writes deviceId + secret permanently to device)
+4. CMD 86 — Verify with the assigned secret
+5. CMD 84 — Time sync
+6. Read/write commands
+
+### Security model
+
+- **Uninitialized devices (deviceId == 0)** accept a zero secret (8 null bytes) for CMD 86. This is the key discovery that enables cloud-free BLE access.
+- **Initialized devices** require the exact 8-byte secret that was written during CMD 73. The secret is generated server-side.
+- CMD 86 response: `data[0] == 1` means success, anything else means failure. On failure, the device may disconnect.
+- Sending commands before authentication causes the device to disconnect.
+
+## Command Reference
+
+### Authentication & Setup Commands
+
+#### CMD 213 — Get Device ID
+- **Direction:** Request → Response
+- **Request payload:** (empty)
+- **Response payload:** 8 bytes deviceId (little-endian) + up to 14 bytes ASCII serial number
+
+#### CMD 86 — Verify Secret
+- **Direction:** Request → Response
+- **Request payload:** 8 bytes (secret, zero-padded)
+- **Response payload:** 1 byte — `0x01` = success, `0x00` = failure
+
+#### CMD 73 — Initialize Device (WRITES PERMANENTLY)
+- **Direction:** Request → Response
+- **Request payload:** 8 bytes deviceId (big-endian) + 8 bytes secret
+- **Response payload:** 1 byte — `0x01` = success
+- **WARNING:** This permanently writes the device ID and secret. Can only be undone with a physical factory reset.
+
+#### CMD 84 — Time Sync
+- **Direction:** Request → Response
+- **Request payload:** 1 byte (0x00) + 4 bytes seconds since 2000-01-01 (big-endian signed int) + 1 byte timezone (UTC offset + 12)
+- **Response payload:** 1 byte — `0x01` = success
+
+### Read Commands
+
+#### CMD 210 — Get Running State
+- **Direction:** Request → Response
+- **Request payload:** (empty)
+- **Response payload (12-16 bytes):**
+
+| Byte | Field | Values |
+|---|---|---|
+| 0 | powerStatus | 0=off, 1=on |
+| 1 | mode | 0=off, 1=normal, 2=smart |
+| 2 | nightNoDisturb | 0/1 |
+| 3 | breakdownWarning | 0/1 |
+| 4 | **lackWarning** | **0=OK, 1=LOW WATER** |
+| 5 | filterWarning | 0/1 |
+| 6-9 | pumpRunTime | 4 bytes big-endian, total seconds |
+| 10 | filterPercent | 0-100, filter life remaining % |
+| 11 | runStatus | 0=idle, 1=running |
+| 12-15 | todayPumpRunTime | (optional) 4 bytes big-endian, seconds today |
+
+The `todayPumpRunTime` field (bytes 12-15) is only present on newer firmware versions:
+- typeCode 2: firmware >= 24
+- Other typeCodes: firmware >= 35
+
+#### CMD 211 — Get Settings
+- **Direction:** Request → Response
+- **Request payload:** (empty)
+- **Response payload (13-14 bytes):**
+
+| Byte | Field | Type |
+|---|---|---|
+| 0 | smartWorkingTime | Minutes (smart mode run duration) |
+| 1 | smartSleepTime | Minutes (smart mode sleep duration) |
+| 2 | lampRingSwitch | 0=off, 1=on |
+| 3 | lampRingBrightness | 0-255 |
+| 4-5 | lampRingLightUpTime | Big-endian, minutes from midnight |
+| 6-7 | lampRingGoOutTime | Big-endian, minutes from midnight |
+| 8 | noDisturbingSwitch | 0=off, 1=on |
+| 9-10 | noDisturbingStartTime | Big-endian, minutes from midnight |
+| 11-12 | noDisturbingEndTime | Big-endian, minutes from midnight |
+| 13 | isLock | (optional) 0/1, child lock |
+
+The `isLock` byte is only present on firmware versions that support it.
+
+#### CMD 200 — Get Hardware/Firmware Version
+- **Direction:** Request → Response
+- **Request payload:** (empty)
+- **Response payload:** 2+ bytes — `[hardware_version, firmware_version, ...]`
+  - Byte 0: hardware revision (integer, e.g. `1`)
+  - Byte 1: firmware version (integer, e.g. `111`)
+  - Additional bytes may be present on some models (CTW3 returns 17 bytes)
+
+#### CMD 66 — Get Battery/Voltage
+- **Direction:** Request → Response
+- **Request payload:** (empty)
+- **Response payload:** 2 bytes — little-endian raw voltage value
+- **Note:** This is a raw ADC value, not a calibrated percentage. Not a reliable water level indicator.
+
+#### CMD 215 — Get Extended Light Settings
+- **Direction:** Request → Response
+- **Request payload:** (empty)
+- **Response payload:**
+
+| Byte | Field |
+|---|---|
+| 0 | lightConfig (1=config mode 1, else mode 2) |
+| 1 | number of time slots |
+| 2-5 | reserved (0) |
+| 6+ | Time slots: 5 bytes each (2B start_minutes_BE, 2B end_minutes_BE, 1B reserved) |
+
+#### CMD 216 — Get Extended DND Settings
+- Same structure as CMD 215 but for Do Not Disturb schedules
+- `disturbConfig` instead of `lightConfig`
+
+### Write Commands
+
+#### CMD 220 — Change Device Mode
+- **Request payload:** 2 bytes — `[mode, submode]`
+- **Modes:** 0=off, 1=normal, 2=smart
+- **Response:** `data[0] == 0` indicates failure
+
+#### CMD 221 — Write All Settings
+- **Request payload (13-14 bytes):**
+
+| Byte | Field |
+|---|---|
+| 0 | smartWorkingTime |
+| 1 | smartSleepTime |
+| 2 | lampRingSwitch |
+| 3 | lampRingBrightness |
+| 4-5 | lampRingLightUpTime (big-endian) |
+| 6-7 | lampRingGoOutTime (big-endian) |
+| 8 | noDisturbingSwitch |
+| 9-10 | noDisturbingStartTime (big-endian) |
+| 11-12 | noDisturbingEndTime (big-endian) |
+| 13 | isLock (if supported) |
+
+#### CMD 222 — Reset Filter
+- **Request payload:** (empty)
+- Resets filter usage counter to 100%.
+
+#### CMD 225 — Update Light Schedule (Extended)
+- **Request payload:**
+
+| Byte | Field |
+|---|---|
+| 0 | lightConfig (1 or 0) |
+| 1 | number of time slots |
+| 2-5 | reserved (0) |
+| 6+ | Time slots: 5 bytes each (2B start, 2B end, 1B 0x00) |
+
+#### CMD 226 — Update DND Schedule (Extended)
+- Same structure as CMD 225 but for Do Not Disturb
+
+#### CMD 83 — Start OTA
+- **Request payload:** (empty)
+- Puts device into OTA (firmware update) mode
+
+#### CMD 230 — Device Push Notification (device-initiated)
+- **Direction:** Device → Phone (unsolicited push)
+- Contains combined state + settings data (25+ bytes)
+- Client should respond with `CMD 230, data=[0x01], type=RESPONSE` to acknowledge
+- Layout varies by firmware version — older firmware uses 25 bytes (12 state + 13 settings), newer firmware inserts 4 bytes of `todayPumpRunTime` between state and settings (29 bytes total)
+
+---
+
+## ha-petkit Implementation Notes
+
+These notes are specific to the `ha-petkit` integration and supplement the protocol
+documentation above with findings from real device log analysis.
+
+### CTW3 Differences
+
+The CTW3 (Eversweet 3 Pro) uses **CMD 211** (state) instead of CMD 210, with a 26+ byte payload:
+
+| Byte | Field |
+|---|---|
+| 0 | powerStatus |
+| 1 | suspendStatus |
+| 2 | mode |
+| 3 | electricStatus |
+| 4 | dndState |
+| 5 | warningBreakdown |
+| 6 | warningWaterMissing |
+| 7 | lowBattery |
+| 8 | warningFilter |
+| 9-12 | pumpRunTime (big-endian uint32, seconds) |
+| 13 | filterPercent |
+| 14 | runningStatus |
+| 15-18 | pumpRuntimeToday (big-endian uint32, seconds) |
+| 19 | detectStatus |
+| 20-21 | supplyVoltageMv (big-endian int16) |
+| 22-23 | batteryVoltageMv (big-endian int16) |
+| 24 | batteryPercent |
+| 25 | moduleStatus |
+
+**CTW3 does NOT respond to CMD 211 (get settings).** The device sends unsolicited
+CMD 230 (0xe6) extended state push notifications but never replies to CMD 211 requests.
+ha-petkit skips CMD 211 for CTW3 to avoid a 5-second timeout per poll.
+
+### Authentication (ha-petkit approach)
+
+ha-petkit uses a **self-init** strategy with a random 8-byte secret:
+
+1. **First connection** (no stored secret):
+   - CMD 213 — fetch device ID
+   - CMD 73 — init with `device_id_be + random_8_byte_secret`
+   - CMD 86 — verify with `random_8_byte_secret`
+   - CMD 84 — set time
+   - Secret is saved to the HA config entry for subsequent connections.
+
+2. **Subsequent connections** (stored secret):
+   - CMD 86 — verify directly with stored secret
+   - CMD 84 — set time
+   - CMD 213 and CMD 73 are skipped.
+
+### CMD 200 — Hardware / Firmware Version Parsing
+
+CTW3 returns 17 bytes from CMD 200. Only bytes 0 and 1 are used:
+- `payload[0]` → `hardware_version` (e.g. `1`)
+- `payload[1]` → `firmware` (e.g. `111`)
+
+### Unsolicited Notifications
+
+The CTW3 sends CMD 230 (0xe6) push notifications at irregular intervals. These must
+not be mistaken for responses to CMD 210 or CMD 211 requests. ha-petkit validates the
+`cmd` byte of every received frame and discards mismatches.


### PR DESCRIPTION
## Changes

### 1. Hardware Version sensor

CMD 200 returns `[hardware_version, firmware_version]` - previously both bytes were combined into a single string (e.g. `1.111`). Now they are parsed separately:

- `payload[0]` -> `hardware_version` (e.g. `1`) - new Hardware Version diagnostic sensor
- `payload[1]` -> `firmware` (e.g. `111`) - existing Firmware sensor (now shows just the number)

Translations added for all three locales (EN/NL/UK).

### 2. Protocol documentation

Added `docs/W5_BLE_PROTOCOL.md` - full protocol reference reproduced from mr-ransel/petkit-ble-reverse-engineering with clear attribution, plus ha-petkit implementation notes.

### 3. Copilot skill

Added `.github/instructions/petkit-ble.instructions.md` with applyTo for custom_components/petkit_ble/**. GitHub Copilot automatically loads this as a custom instruction when working on files in the integration directory.