### PR TITLE
fix: invert CTW3 suspend_status sensor logic

### DIFF
--- a/custom_components/petkit_ble/binary_sensor.py
+++ b/custom_components/petkit_ble/binary_sensor.py
@@ -86,7 +86,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PetkitBinarySensorDescription, ...] = (
         key="suspended",
         translation_key="suspended",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda d: bool(d.suspend_status),
+        value_fn=lambda d: not bool(d.suspend_status),
         available_fn=lambda d: d.is_ctw3,
     ),
 )


### PR DESCRIPTION
## Probleem
suspend_status=1 wanneer de pomp normaal draait — het veld betekent dus 'actief' (niet gesuspended).
De binary sensor 'Pump Suspended' toonde ON terwijl de pomp liep: omgekeerd.

## Fix
\alue_fn=lambda d: not bool(d.suspend_status)\
→ sensor is ON wanneer suspend_status=0 (gesuspended), OFF wanneer suspend_status=1 (actief/lopend)

Bevestigd door gebruiker via log-analyse: payload[1]=0x01 in alle responses bij normaal draaiende pomp.