### PR TITLE
fix: move GATT serial number read to after Petkit auth sequence

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -420,14 +420,6 @@ class PetkitBleClient:
         data = PetkitFountainData(alias=alias)
         try:
             await self._connect()
-
-            # GATT Device Information Service — serial number (standard BLE, no auth needed)
-            assert self._client is not None
-            with contextlib.suppress(Exception):
-                sn_bytes = await self._client.read_gatt_char(GATT_SERIAL_NUMBER_UUID)
-                data.serial_number = sn_bytes.decode("utf-8", errors="ignore").strip()
-                _LOGGER.debug("Serial number: %s", data.serial_number)
-
             await self._authenticate(alias, secret)
 
             # CMD 200 — firmware version: byte[0]=hardware revision, byte[1]=firmware version
@@ -460,6 +452,15 @@ class PetkitBleClient:
             payload_66 = await self._send_and_wait(CMD_GET_BATTERY, FRAME_TYPE_SEND, [0, 0])
             if payload_66 is not None and len(payload_66) >= 2:
                 data.battery_voltage_mv_66 = payload_66[0] + payload_66[1] * 256
+
+            # GATT Device Information Service — serial number (standard BLE).
+            # Read AFTER all Petkit commands: some devices disconnect when unsupported
+            # GATT characteristics are accessed before the application-level auth completes.
+            assert self._client is not None
+            with contextlib.suppress(Exception):
+                sn_bytes = await self._client.read_gatt_char(GATT_SERIAL_NUMBER_UUID)
+                data.serial_number = sn_bytes.decode("utf-8", errors="ignore").strip()
+                _LOGGER.debug("Serial number: %s", data.serial_number)
 
         finally:
             await self.disconnect()

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -57,10 +57,14 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             try:
                 data = await client.async_poll(self._alias, self._secret)
             except Exception as exc:
+                # Clear the stored secret so the next poll attempts a full re-initialisation
+                # (CMD 213 + CMD 73 + CMD 86).  This recovers the common case where another
+                # BLE client (e.g. the official iOS app) has changed the device's auth state.
+                self._secret = None
                 raise UpdateFailed(f"Error communicating with {self._name}: {exc}") from exc
 
-            # Persist the secret after first-time device initialisation
-            if self._secret is None and client.used_secret is not None:
+            # Persist the secret after first-time or re-initialisation
+            if client.used_secret is not None and client.used_secret != self._secret:
                 self._secret = client.used_secret
                 new_data = {**self._config_entry.data, CONF_DEVICE_SECRET: self._secret.hex()}
                 self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)


### PR DESCRIPTION
## Root cause

The GATT serial number read (\