### PR TITLE
fix: always perform full auth re-init (CMD 73) on every BLE connection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,23 +63,21 @@ custom_components/petkit_ble/
 ```
 
 ### Authentication Sequence (every connection)
-1. **CMD 213** — request device ID
-2. **CMD 73** — request challenge bytes
-3. **CMD 86** — send computed secret; response[0] must equal `1` for success
+1. **CMD 213** — request device ID (big-endian for CMD 73 payload)
+2. **CMD 73** — register a fresh random 8-byte secret: `device_id_be + random_8_bytes`
+3. **CMD 86** — verify the same secret; response[0] must equal `1` for success
 4. **CMD 84** — set device time (Petkit epoch: 2000-01-01, offset = 946684800)
 
-### CTW3 Authentication Quirk (CRITICAL)
-Always use `[0]*6` as the `device_id` for secret computation, **regardless** of what
-CMD 213 returns. Using the actual CMD 213 bytes causes CMD 86 to fail and the device
-disconnects silently.
+**Why always full re-init (CMD 73 every connection):** CMD 86 returns `response[0]=1`
+("success") even with a stale or wrong secret — it is a false positive. The device only
+enters an authenticated session if CMD 73 was sent first in the current connection.
+Skipping CMD 73 causes CMD 200/210 to be silently ignored. Running CMD 73 on every
+connection makes the integration immune to the iOS app (or any other BLE client)
+resetting the device's auth state.
 
-### Secret Computation
-```python
-base = list(reversed([0]*6))          # always [0,0,0,0,0,0]
-if base[-2] == 0 and base[-1] == 0:
-    base[-2], base[-1] = 13, 37
-secret = [0] * (8 - len(base)) + base  # left-pad to 8 bytes
-```
+### CTW3 Authentication Note
+CMD 73 uses the device_id from CMD 213 converted to big-endian; followed by a new
+`secrets.token_bytes(8)` generated per connection. No fixed/hardcoded values needed.
 
 ### Key Commands
 | CMD | Direction | Purpose |

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -143,7 +143,6 @@ class PetkitBleClient:
         self._rx_buf: bytearray = bytearray()
         self._rx_queue: asyncio.Queue[bytes] = asyncio.Queue()
         self._seq: int = 0
-        self.used_secret: bytes | None = None
 
     # ------------------------------------------------------------------
     # Frame encode / decode
@@ -278,42 +277,37 @@ class PetkitBleClient:
     # Authentication sequence
     # ------------------------------------------------------------------
 
-    async def _authenticate(self, alias: str, secret: bytes | None = None) -> None:
-        """Run the Petkit authentication sequence.
+    async def _authenticate(self, alias: str) -> None:
+        """Run the full Petkit authentication sequence every connection.
 
-        On first connection (secret=None), fetches the device ID, generates a random
-        8-byte secret, initialises the device with CMD 73, then verifies with CMD 86.
-        The generated secret is stored in self.used_secret for the coordinator to persist.
-
-        On subsequent connections, verifies directly with CMD 86 using the stored secret.
+        Always performs CMD 213 → CMD 73 → CMD 86 → CMD 84 to guarantee a valid
+        session, regardless of whether another BLE client (e.g. the iOS app) has
+        connected in the meantime.  This prevents the "false-positive CMD 86" issue
+        where the device accepts a stale secret in CMD 86 but ignores subsequent
+        state commands because no CMD 73 was sent in the current session.
         """
-        if secret is None:
-            # First-time initialisation: fetch device ID and generate a random secret
-            payload_213 = await self._send_and_wait(CMD_GET_DEVICE_INFO, FRAME_TYPE_SEND, [])
-            if payload_213 is None or len(payload_213) < 8:
-                byte_count = len(payload_213) if payload_213 is not None else 0
-                raise RuntimeError(f"CMD 213 failed or response too short (got {byte_count} bytes)")
-            # Convert device_id bytes to big-endian for CMD 73 payload
-            device_id_be = struct.pack(">q", int.from_bytes(payload_213[:8], "little"))
-            new_secret = secrets.token_bytes(8)
+        # CMD 213 — get device ID
+        payload_213 = await self._send_and_wait(CMD_GET_DEVICE_INFO, FRAME_TYPE_SEND, [])
+        if payload_213 is None or len(payload_213) < 8:
+            byte_count = len(payload_213) if payload_213 is not None else 0
+            raise RuntimeError(f"CMD 213 failed or response too short (got {byte_count} bytes)")
+        device_id_be = struct.pack(">q", int.from_bytes(payload_213[:8], "little"))
+        new_secret = secrets.token_bytes(8)
 
-            await asyncio.sleep(AUTH_STEP_DELAY)
-            await self._send_and_wait(CMD_AUTH_INIT, FRAME_TYPE_SEND, list(device_id_be) + list(new_secret))
-            await asyncio.sleep(AUTH_STEP_DELAY)
+        await asyncio.sleep(AUTH_STEP_DELAY)
 
-            auth_secret = new_secret
-            _LOGGER.debug("First-time device initialisation complete for %s", alias)
-        else:
-            auth_secret = secret
+        # CMD 73 — register the new random secret with the device
+        await self._send_and_wait(CMD_AUTH_INIT, FRAME_TYPE_SEND, list(device_id_be) + list(new_secret))
+        await asyncio.sleep(AUTH_STEP_DELAY)
 
         # CMD 86 — verify secret; response[0]==1 means success
-        payload_86 = await self._send_and_wait(CMD_AUTH_VERIFY, FRAME_TYPE_SEND, list(auth_secret))
+        payload_86 = await self._send_and_wait(CMD_AUTH_VERIFY, FRAME_TYPE_SEND, list(new_secret))
         await asyncio.sleep(AUTH_STEP_DELAY)
         if payload_86 is None or len(payload_86) == 0 or payload_86[0] != 1:
             resp_hex = payload_86.hex() if payload_86 else "None"
             raise RuntimeError(f"Authentication failed (CMD 86 response: {resp_hex})")
 
-        self.used_secret = auth_secret
+        _LOGGER.debug("Authentication complete for %s", alias)
 
         # CMD 84 — set device time
         sec = int(time.time()) - PETKIT_EPOCH_OFFSET
@@ -411,16 +405,15 @@ class PetkitBleClient:
     # Public API
     # ------------------------------------------------------------------
 
-    async def async_poll(self, alias: str, secret: bytes | None = None) -> PetkitFountainData:
+    async def async_poll(self, alias: str) -> PetkitFountainData:
         """Connect, authenticate, poll all state commands, disconnect.
 
         Returns a fully-populated PetkitFountainData instance.
-        The generated or used secret is stored in self.used_secret after success.
         """
         data = PetkitFountainData(alias=alias)
         try:
             await self._connect()
-            await self._authenticate(alias, secret)
+            await self._authenticate(alias)
 
             # CMD 200 — firmware version: byte[0]=hardware revision, byte[1]=firmware version
             payload_200 = await self._send_and_wait(CMD_GET_FIRMWARE, FRAME_TYPE_SEND, [])
@@ -472,7 +465,6 @@ class PetkitBleClient:
         cmd: int,
         data: list[int],
         alias: str,
-        secret: bytes | None = None,
     ) -> bool:
         """Connect, authenticate, send a single command, disconnect.
 
@@ -480,7 +472,7 @@ class PetkitBleClient:
         """
         try:
             await self._connect()
-            await self._authenticate(alias, secret)
+            await self._authenticate(alias)
             await self._send_and_wait(cmd, FRAME_TYPE_SEND, data)
         except Exception:
             _LOGGER.exception("Error sending CMD %d", cmd)

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from .ble_client import PetkitBleClient, PetkitFountainData
-from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
+from .const import CONF_ADDRESS, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,9 +30,6 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         self._name: str = config_entry.data[CONF_NAME]
         self._config_entry = config_entry
         self._ble_lock = asyncio.Lock()
-
-        secret_hex = config_entry.data.get(CONF_DEVICE_SECRET)
-        self._secret: bytes | None = bytes.fromhex(secret_hex) if secret_hex else None
 
         super().__init__(
             hass,
@@ -55,20 +52,9 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             if client is None:
                 raise UpdateFailed(f"Petkit fountain {self._name} ({self._address}) not reachable via Bluetooth")
             try:
-                data = await client.async_poll(self._alias, self._secret)
+                data = await client.async_poll(self._alias)
             except Exception as exc:
-                # Clear the stored secret so the next poll attempts a full re-initialisation
-                # (CMD 213 + CMD 73 + CMD 86).  This recovers the common case where another
-                # BLE client (e.g. the official iOS app) has changed the device's auth state.
-                self._secret = None
                 raise UpdateFailed(f"Error communicating with {self._name}: {exc}") from exc
-
-            # Persist the secret after first-time or re-initialisation
-            if client.used_secret is not None and client.used_secret != self._secret:
-                self._secret = client.used_secret
-                new_data = {**self._config_entry.data, CONF_DEVICE_SECRET: self._secret.hex()}
-                self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
-                _LOGGER.info("Device secret saved for %s (%s)", self._name, self._address)
 
         _LOGGER.debug(
             "Polled %s: power=%s mode=%s firmware=%s", self._name, data.power_status, data.mode, data.firmware
@@ -97,4 +83,4 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
                     self._address,
                 )
                 return False
-            return await client.async_send_command(cmd, data, self._alias, self._secret)
+            return await client.async_send_command(cmd, data, self._alias)


### PR DESCRIPTION
## Problem

CMD 86 returns response[0]=1 (false positive) regardless of whether the secret matches. The device only enters a properly authenticated session if CMD 73 was sent first in the current connection.

### What happens with the iOS app

1. iOS app connects, sends CMD 73 with its own secret, authenticates, disconnects
2. HA connects, skips CMD 73 (stored secret short-path), sends CMD 86, device returns 1 (false positive)
3. Device is NOT actually authenticated, CMD 200/210 silently ignored, poll fails with UpdateFailed
4. Next poll cycle (60 seconds later): was: secret cleared + full re-init. Now: never happens.

## Fix

Always run the full auth sequence on every connection: CMD 213 -> CMD 73 (new random secret) -> CMD 86 -> CMD 84

This guarantees a valid authenticated session regardless of what any other BLE client has done.

## Changes

- ble_client.py: _authenticate(alias) always runs CMD 213 + CMD 73 + CMD 86 + CMD 84
- ble_client.py: Removed used_secret attribute and secret parameters from async_poll / async_send_command
- coordinator.py: Removed all secret persistence logic (no longer needed)
- .github/copilot-instructions.md: Updated auth documentation

## Impact

- ~2 extra BLE round trips per 60-second poll (~1-2s additional connection time)
- Fully immune to iOS app or any other BLE client resetting device auth state
- Simpler code: one auth path instead of two