### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
Bump manifest version from 1.0.1 to 1.1.0 so the release workflow creates a production release on merge to main.

Tag v1.0.1 already exists from a previous release, so no release was created when PR #30 was merged.