### PR TITLE
Release v1.1.0

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
## Release v1.1.0

Version bump to 1.1.0 to trigger production release workflow.

See PR #30 for full changelog of features, fixes, and improvements included in this release.