### PR TITLE
fix: remove pump-running requirement from drink event detection

### DIFF
--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -72,11 +72,12 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             "Polled %s: power=%s mode=%s firmware=%s", self._name, data.power_status, data.mode, data.firmware
         )
 
-        # Track drink events: detect_status transitions 0→1 while pump is running
+        # Track drink events: detect_status transitions 0→1
+        # No pump check — in smart mode the pump may be off while pet drinks
         cur_detect = data.detect_status
-        cur_pump = data.is_pump_running
-        if self._prev_detect_status is not None and self._prev_detect_status == 0 and cur_detect == 1 and cur_pump:
+        if self._prev_detect_status is not None and self._prev_detect_status == 0 and cur_detect == 1:
             self._drink_event_count += 1
+            _LOGGER.debug("Drink event detected (count=%d)", self._drink_event_count)
         self._prev_detect_status = cur_detect
         data.drink_event_count = self._drink_event_count
 


### PR DESCRIPTION
## Problem
The drink event counter (Drinkgebeurtenissen vandaag) stays at 0 even when pet_detected (Huisdier drinkt) turns on.

## Root Cause
The drink event detection required three conditions:
1. \detect_status\ transition from 0→1 ✅
2. Previous \detect_status == 0\ ✅
3. \is_pump_running == True\ ❌ — in smart mode the pump may already be off

## Fix
Remove the \is_pump_running\ requirement. A \detect_status\ 0→1 transition alone is sufficient to count a drink event. Added debug logging for drink event detection.

## Testing
- All 39 tests pass
- Ruff lint + format clean