### PR TITLE
docs: add Petkit CTW3 dashboard YAML and README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ HA will scan for nearby Petkit fountains automatically. If none appear, enter th
 
 The integration polls the fountain every 60 seconds. Commands (pump on/off, filter reset) connect on demand and refresh the state immediately after.
 
+## Dashboard
+
+A ready-made dashboard YAML is included in [`docs/dashboard.yaml`](docs/dashboard.yaml) that mirrors the Petkit iOS app layout.
+
+### Import the dashboard
+
+1. In Home Assistant, go to **Settings → Dashboards → Add Dashboard**
+2. Choose **New dashboard from scratch**
+3. Open the new dashboard, click ⋮ → **Edit dashboard** → ⋮ → **Raw configuration editor**
+4. Paste the contents of [`docs/dashboard.yaml`](docs/dashboard.yaml)
+5. Save
+
+> **Note:** The YAML uses entity prefix `petkit_ctw3_100`. If your device has a different prefix, use find-and-replace to update all entity IDs.
+
+### Sections
+
+| Section | Contents |
+|---------|----------|
+| **Controls** | Power switch, mode selector (Normal/Smart) |
+| **Status** | Pump running, pet drinking, AC power, DND, warnings |
+| **Daily Statistics** | Water purified, energy used, pump runtime, drink events |
+| **Filter** | Filter life gauge, days remaining, reset button |
+| **Battery** | Battery gauge, voltage, AC power, pump suspended |
+| **Settings** | Smart work/sleep timing, LED brightness & schedule, DND schedule |
+| **Device Info** | Firmware, hardware version, BLE RSSI, total pump runtime, UVC |
+
+---
+
 ## Protocol Notes
 
 Communication uses a proprietary BLE protocol over two GATT characteristics (notify + write-without-response). Authentication is required on every connection.

--- a/docs/dashboard.yaml
+++ b/docs/dashboard.yaml
@@ -1,0 +1,192 @@
+##############################################################################
+# Petkit BLE Water Fountain – Home Assistant Dashboard
+#
+# A single-page dashboard that mirrors the Petkit iOS app layout.
+# Replace "petkit_ctw3_100" with your own device entity prefix if different.
+#
+# Import: Settings → Dashboards → Add → paste this YAML in raw editor.
+##############################################################################
+
+title: Petkit Water Fountain
+views:
+  - title: Petkit CTW3
+    path: petkit
+    type: sections
+    sections:
+      # ── Controls ──────────────────────────────────────────────────────
+      - title: Controls
+        type: grid
+        cards:
+          - type: heading
+            heading: "🐾 Petkit CTW3"
+            heading_style: title
+
+          - type: entities
+            entities:
+              - entity: switch.petkit_ctw3_100_power
+                name: Power
+              - entity: select.petkit_ctw3_100_mode
+                name: Mode
+
+      # ── Live Status ──────────────────────────────────────────────────
+      - title: Status
+        type: grid
+        cards:
+          - type: glance
+            entities:
+              - entity: binary_sensor.petkit_ctw3_100_pump_running
+                name: Pump
+              - entity: binary_sensor.petkit_ctw3_100_pet_detected
+                name: Pet Drinking
+              - entity: binary_sensor.petkit_ctw3_100_on_ac_power
+                name: AC Power
+              - entity: binary_sensor.petkit_ctw3_100_dnd_active
+                name: DND
+            show_state: true
+
+          - type: glance
+            entities:
+              - entity: binary_sensor.petkit_ctw3_100_warning_water_missing
+                name: No Water
+              - entity: binary_sensor.petkit_ctw3_100_warning_filter
+                name: Filter Warn
+              - entity: binary_sensor.petkit_ctw3_100_warning_breakdown
+                name: Breakdown
+              - entity: binary_sensor.petkit_ctw3_100_low_battery
+                name: Low Battery
+            show_state: true
+
+      # ── Daily Statistics ─────────────────────────────────────────────
+      - title: Daily Statistics
+        type: grid
+        cards:
+          - type: statistic
+            entity: sensor.petkit_ctw3_100_water_purified_today
+            name: Water Purified
+            period:
+              calendar:
+                period: day
+            stat_type: state
+
+          - type: statistic
+            entity: sensor.petkit_ctw3_100_energy_today
+            name: Energy Used
+            period:
+              calendar:
+                period: day
+            stat_type: state
+
+          - type: entity
+            entity: sensor.petkit_ctw3_100_pump_runtime_today
+            name: Pump Runtime Today
+
+          - type: entity
+            entity: sensor.petkit_ctw3_100_drink_count
+            name: Drink Events
+            icon: mdi:cup-water
+
+      # ── Filter ───────────────────────────────────────────────────────
+      - title: Filter
+        type: grid
+        cards:
+          - type: gauge
+            entity: sensor.petkit_ctw3_100_filter_percent
+            name: Filter Life
+            min: 0
+            max: 100
+            severity:
+              green: 50
+              yellow: 20
+              red: 0
+
+          - type: entity
+            entity: sensor.petkit_ctw3_100_filter_days_remaining
+            name: Days Remaining
+            icon: mdi:calendar-clock
+
+          - type: button
+            entity: button.petkit_ctw3_100_reset_filter
+            name: Reset Filter
+            icon: mdi:filter-remove
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.petkit_ctw3_100_reset_filter
+              confirmation:
+                text: "Are you sure you want to reset the filter counter?"
+
+      # ── Battery & Power ──────────────────────────────────────────────
+      - title: Battery
+        type: grid
+        cards:
+          - type: gauge
+            entity: sensor.petkit_ctw3_100_battery_percent
+            name: Battery
+            min: 0
+            max: 100
+            severity:
+              green: 50
+              yellow: 20
+              red: 0
+
+          - type: entity
+            entity: sensor.petkit_ctw3_100_battery_voltage_mv
+            name: Battery Voltage
+
+          - type: entity
+            entity: binary_sensor.petkit_ctw3_100_on_ac_power
+            name: AC Power
+
+          - type: entity
+            entity: binary_sensor.petkit_ctw3_100_suspended
+            name: Pump Suspended
+
+      # ── Smart Mode Settings ──────────────────────────────────────────
+      - title: Smart Mode Settings
+        type: grid
+        cards:
+          - type: entities
+            title: Smart Mode Timing
+            entities:
+              - entity: number.petkit_ctw3_100_smart_work_minutes
+                name: Work Duration (min)
+              - entity: number.petkit_ctw3_100_smart_sleep_minutes
+                name: Sleep Duration (min)
+
+          - type: entities
+            title: LED Schedule
+            entities:
+              - entity: number.petkit_ctw3_100_led_brightness
+                name: LED Brightness
+              - entity: time.petkit_ctw3_100_led_on_time
+                name: LED On Time
+              - entity: time.petkit_ctw3_100_led_off_time
+                name: LED Off Time
+
+          - type: entities
+            title: Do Not Disturb
+            entities:
+              - entity: time.petkit_ctw3_100_dnd_start_time
+                name: DND Start
+              - entity: time.petkit_ctw3_100_dnd_end_time
+                name: DND End
+
+      # ── Device Info ──────────────────────────────────────────────────
+      - title: Device Info
+        type: grid
+        cards:
+          - type: entities
+            entities:
+              - entity: sensor.petkit_ctw3_100_firmware
+                name: Firmware
+              - entity: sensor.petkit_ctw3_100_hardware_version
+                name: Hardware
+              - entity: sensor.petkit_ctw3_100_rssi
+                name: BLE Signal (RSSI)
+              - entity: sensor.petkit_ctw3_100_pump_runtime
+                name: Total Pump Runtime
+
+          - type: entity
+            entity: binary_sensor.petkit_ctw3_100_uvc_active
+            name: UVC Sterilization


### PR DESCRIPTION
## Summary

Adds a ready-to-import Home Assistant dashboard YAML that mirrors the Petkit iOS app layout.

### Changes
- **docs/dashboard.yaml** — Full dashboard with sections: Controls, Status, Daily Stats, Filter, Battery, Settings, Device Info
- **README.md** — New Dashboard section with import instructions and section overview table

### Entity prefix
Uses \petkit_ctw3_100\ — users with a different prefix can find-and-replace.

### Dashboard sections
| Section | Contents |
|---------|----------|
| Controls | Power switch, mode selector |
| Status | Pump, pet detected, AC, DND, warnings |
| Daily Statistics | Water, energy, pump runtime, drink events |
| Filter | Life gauge, days remaining, reset button |
| Battery | Gauge, voltage, AC, suspended |
| Settings | Smart timing, LED, DND schedule |
| Device Info | Firmware, hardware, RSSI, UVC |