### PR TITLE
Chore/ha integration developer skill

### DIFF
--- a/.agents/skills/home-assistant-integration-developer/SKILL.md
+++ b/.agents/skills/home-assistant-integration-developer/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: home-assistant-integration-developer
+description: >
+  Best practices for developing Home Assistant custom integrations — config flows, coordinators,
+  entity platforms, BLE protocol, translations, manifest, and code quality.
+
+  TRIGGER THIS SKILL WHEN:
+  - Creating or modifying a Home Assistant custom integration
+  - Adding new entity platforms (sensor, switch, number, time, select, button, binary_sensor)
+  - Writing or refactoring a config flow (user, bluetooth, options)
+  - Implementing a DataUpdateCoordinator for polling or push data
+  - Creating BLE/Bluetooth integrations with bleak or HA bluetooth stack
+  - Adding translation strings or entity descriptions
+  - Setting up manifest.json with BLE matchers or dependencies
+  - Writing entity description dataclasses with value extractors
+  - Implementing device commands (write-back) through coordinator
+  - Structuring __init__.py setup/unload with runtime_data pattern
+
+  SYMPTOMS:
+  - Agent creates entities in __init__.py instead of platform files
+  - Agent uses hass.data[DOMAIN] instead of entry.runtime_data pattern
+  - Agent does network I/O in entity properties instead of coordinator
+  - Agent skips DataUpdateCoordinator and polls directly from entities
+  - Agent uses device_id instead of entity_id in entity unique IDs
+  - Agent forgets from __future__ import annotations or type hints
+  - Agent imports Callable from typing instead of collections.abc
+  - Agent duplicates payload-building logic across multiple platform files
+  - Agent uses mutable state in entity description dataclasses (missing frozen=True)
+  - Agent stores secrets in code instead of config entry data
+  - Agent skips translation_key and hardcodes entity names
+  - Agent catches bare Exception without re-raising as UpdateFailed
+  - Agent creates config entries without calling async_set_unique_id first
+  - Agent accesses private fields (_underscore) across module boundaries
+
+metadata:
+  version: 1
+---
+
+# Home Assistant Integration Developer
+
+**Core principle:** Follow Home Assistant's native patterns — `DataUpdateCoordinator` for data fetching, `entry.runtime_data` for state, `CoordinatorEntity` for entities, frozen dataclass descriptions for entity metadata, and `strings.json` for all user-visible text.
+
+## Decision Workflow
+
+Follow this sequence when creating or modifying an integration:
+
+### 0. Gate: Custom integration or core?
+
+This skill covers **custom integrations** installed via HACS or manually in `custom_components/`.
+Core integrations follow stricter rules (quality scale, hassfest). The patterns here are compatible
+with both but optimized for custom component development.
+
+### 1. Project structure
+
+Every integration lives in `custom_components/<domain>/` with this layout:
+
+```
+custom_components/<domain>/
+├── __init__.py          # Setup/unload, platform forwarding
+├── manifest.json        # Metadata, dependencies, BLE matchers
+├── const.py             # All constants (UUIDs, command IDs, defaults)
+├── config_flow.py       # Config flow + options flow
+├── coordinator.py       # DataUpdateCoordinator
+├── entity.py            # Base entity class (CoordinatorEntity)
+├── protocol.py          # Protocol helpers (payload builders, shared logic)
+├── <client>.py          # Device client (BLE, API, etc.)
+├── sensor.py            # Sensor platform
+├── binary_sensor.py     # Binary sensor platform
+├── switch.py            # Switch platform
+├── button.py            # Button platform
+├── number.py            # Number platform
+├── time.py              # Time platform
+├── select.py            # Select platform
+├── strings.json         # Source-of-truth translations (English)
+└── translations/        # Per-language translations
+    ├── en.json
+    └── <lang>.json
+```
+
+### 2. Manifest.json
+
+Required fields:
+```json
+{
+  "domain": "my_integration",
+  "name": "My Integration",
+  "version": "1.0.0",
+  "config_flow": true,
+  "documentation": "https://github.com/...",
+  "issue_tracker": "https://github.com/.../issues",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": ["@username"],
+  "iot_class": "local_polling"
+}
+```
+
+For Bluetooth integrations, add:
+```json
+{
+  "bluetooth": [{"connectable": true, "local_name": "DeviceName_*"}],
+  "dependencies": ["bluetooth", "bluetooth_adapters"]
+}
+```
+
+See `references/manifest-guide.md` for all fields and iot_class values.
+
+### 3. Config flow pattern
+
+See `references/config-flow-guide.md` for detailed patterns. Key rules:
+
+- Always call `async_set_unique_id()` + `self._abort_if_unique_id_configured()` first
+- Normalize MAC addresses to uppercase
+- Store secrets in `config_entry.data[CONF_SECRET]`, never in code
+- Use `vol.Schema` for input validation
+- Keep config flow lightweight — no heavy I/O
+- For Bluetooth: implement `async_step_bluetooth()` for auto-discovery
+
+### 4. DataUpdateCoordinator
+
+See `references/coordinator-guide.md`. Key rules:
+
+- One coordinator per config entry, stored in `entry.runtime_data`
+- Override `_async_update_data()` — raise `UpdateFailed` on errors
+- Use `asyncio.Lock()` for serial device access (BLE, serial ports)
+- Call `async_request_refresh()` after write commands
+- Never do I/O outside the coordinator
+
+### 5. Entity pattern
+
+See `references/entity-guide.md`. Key rules:
+
+- All entities inherit from a base `CoordinatorEntity` subclass
+- Use frozen dataclass descriptions with `value_fn` / `available_fn`
+- Set `_attr_has_entity_name = True` for automatic naming
+- Unique ID format: `{normalized_address}_{key}`
+- Properties must be O(1) — extract from `coordinator.data` only
+- Return `None` when data is unavailable
+
+### 6. Code quality
+
+- `from __future__ import annotations` in every file
+- Full type annotations on all functions and parameters
+- `Callable` from `collections.abc`, not `typing`
+- Use `| None` instead of `Optional[]`
+- Ruff for linting and formatting
+- Conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`)
+
+---
+
+## Critical Anti-Patterns
+
+| Anti-pattern | Use instead | Why | Reference |
+|---|---|---|---|
+| `hass.data[DOMAIN][entry_id]` | `entry.runtime_data` | Modern pattern (HA 2024.1+), type-safe, auto-cleanup | `references/coordinator-guide.md` |
+| Network I/O in entity property | `coordinator._async_update_data()` | Properties must be sync and O(1) | `references/entity-guide.md` |
+| Creating entities in `__init__.py` | `async_setup_entry()` in platform files | Platform forwarding ensures proper lifecycle | `references/entity-guide.md` |
+| `from typing import Callable` | `from collections.abc import Callable` | Python 3.12+ / ruff UP035 | `references/code-quality.md` |
+| Bare `except Exception` in coordinator | `except SpecificError as err: raise UpdateFailed(...) from err` | Preserve error chain, don't swallow bugs | `references/coordinator-guide.md` |
+| Mutable entity description | `@dataclass(frozen=True, kw_only=True)` | Descriptions are shared across instances | `references/entity-guide.md` |
+| Duplicated logic across platforms | Shared helper in `protocol.py` | Single source of truth for payload building | `references/entity-guide.md` |
+| Private field access across modules | Make fields public or use properties | `data._field` breaks encapsulation | `references/code-quality.md` |
+| Hardcoded entity names | `translation_key` + `strings.json` | Required for multi-language support | `references/translations-guide.md` |
+| `TOTAL_INCREASING` for in-memory counter | `MEASUREMENT` or persist with `RestoreEntity` | Resets on restart look like counter decreases | `references/entity-guide.md` |
+| `struct.pack(">q", id)` for unsigned IDs | `struct.pack(">Q", id)` (unsigned) | High-bit IDs raise `struct.error` with signed | `references/code-quality.md` |
+| Config entry without `async_set_unique_id` | Always set unique ID first | Prevents duplicate entries | `references/config-flow-guide.md` |
+| Secrets in source code | `config_entry.data[CONF_SECRET]` | Secrets must be stored encrypted in config | `references/config-flow-guide.md` |
+| `bytes.fromhex()` without try/except | Wrap in try/except ValueError | Corrupted config data crashes integration | `references/coordinator-guide.md` |
+
+---
+
+## Reference Files
+
+Read these when you need detailed information:
+
+| File | When to read | Key sections |
+|------|--------------|--------------|
+| `references/manifest-guide.md` | Creating or updating manifest.json | `#required-fields`, `#bluetooth-matchers`, `#iot-class`, `#dependencies` |
+| `references/config-flow-guide.md` | Writing config flows (user, bluetooth, options) | `#bluetooth-discovery`, `#user-step`, `#options-flow`, `#unique-id`, `#secrets` |
+| `references/coordinator-guide.md` | Implementing DataUpdateCoordinator | `#setup-pattern`, `#error-handling`, `#write-commands`, `#locking`, `#runtime-data` |
+| `references/entity-guide.md` | Creating entity platforms and descriptions | `#base-entity`, `#descriptions`, `#device-info`, `#availability`, `#platforms` |
+| `references/translations-guide.md` | Adding or updating translation strings | `#strings-json`, `#translation-keys`, `#config-flow-strings`, `#entity-names` |
+| `references/ble-integration-guide.md` | Building Bluetooth/BLE integrations | `#gatt-characteristics`, `#frame-format`, `#authentication`, `#esphome-proxies` |
+| `references/code-quality.md` | Code style, type hints, linting, testing | `#type-hints`, `#ruff`, `#imports`, `#testing` |

--- a/.agents/skills/home-assistant-integration-developer/SKILL.md
+++ b/.agents/skills/home-assistant-integration-developer/SKILL.md
@@ -164,7 +164,7 @@ See `references/entity-guide.md`. Key rules:
 | `TOTAL_INCREASING` for in-memory counter | `MEASUREMENT` or persist with `RestoreEntity` | Resets on restart look like counter decreases | `references/entity-guide.md` |
 | `struct.pack(">q", id)` for unsigned IDs | `struct.pack(">Q", id)` (unsigned) | High-bit IDs raise `struct.error` with signed | `references/code-quality.md` |
 | Config entry without `async_set_unique_id` | Always set unique ID first | Prevents duplicate entries | `references/config-flow-guide.md` |
-| Secrets in source code | `config_entry.data[CONF_SECRET]` | Secrets must be stored encrypted in config | `references/config-flow-guide.md` |
+| Secrets in source code | `config_entry.data[CONF_SECRET]` | Store secrets in config entry storage, not hardcoded in the integration | `references/config-flow-guide.md` |
 | `bytes.fromhex()` without try/except | Wrap in try/except ValueError | Corrupted config data crashes integration | `references/coordinator-guide.md` |
 
 ---

--- a/.agents/skills/home-assistant-integration-developer/SKILL.md
+++ b/.agents/skills/home-assistant-integration-developer/SKILL.md
@@ -71,7 +71,7 @@ custom_components/<domain>/
 ├── number.py            # Number platform
 ├── time.py              # Time platform
 ├── select.py            # Select platform
-├── strings.json         # Source-of-truth translations (English)
+├── strings.json         # Config/options flow strings (English); entity strings live in translations/en.json
 └── translations/        # Per-language translations
     ├── en.json
     └── <lang>.json

--- a/.agents/skills/home-assistant-integration-developer/SKILL.md
+++ b/.agents/skills/home-assistant-integration-developer/SKILL.md
@@ -38,7 +38,7 @@ metadata:
 
 # Home Assistant Integration Developer
 
-**Core principle:** Follow Home Assistant's native patterns — `DataUpdateCoordinator` for data fetching, `entry.runtime_data` for state, `CoordinatorEntity` for entities, frozen dataclass descriptions for entity metadata, and `strings.json` for all user-visible text.
+**Core principle:** Follow Home Assistant's native patterns — `DataUpdateCoordinator` for data fetching, `entry.runtime_data` for state, `CoordinatorEntity` for entities, frozen dataclass descriptions for entity metadata, and the repository's current translation layout: use `strings.json` for config/options flow text and `translations/en.json` (mirrored to other `translations/*.json` files) for entity and other user-visible platform strings.
 
 ## Decision Workflow
 

--- a/.agents/skills/home-assistant-integration-developer/references/ble-integration-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/ble-integration-guide.md
@@ -92,7 +92,7 @@ async def _send_and_wait(self, cmd: int, payload: bytes) -> bytes | None:
 
     try:
         await asyncio.wait_for(self._response_event.wait(), timeout=5.0)
-    except TimeoutError:
+    except asyncio.TimeoutError:
         return None
 
     return self._response_data

--- a/.agents/skills/home-assistant-integration-developer/references/ble-integration-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/ble-integration-guide.md
@@ -1,0 +1,112 @@
+# BLE Integration Guide
+
+## Overview
+
+Home Assistant provides a native Bluetooth stack that supports both local adapters and
+ESPHome Bluetooth proxies transparently. Use `async_ble_device_from_address()` to get
+a connectable BLE device — HA handles routing through the best available adapter.
+
+## GATT Characteristics
+
+Define UUIDs as constants:
+
+```python
+WRITE_CHAR_UUID = "0000aaa2-0000-1000-8000-00805f9b34fb"
+NOTIFY_CHAR_UUID = "0000aaa1-0000-1000-8000-00805f9b34fb"
+```
+
+## Connection Pattern
+
+```python
+from homeassistant.components.bluetooth import async_ble_device_from_address
+
+async def async_connect(self) -> None:
+    """Connect to device."""
+    ble_device = async_ble_device_from_address(
+        self.hass, self._address, connectable=True
+    )
+    if ble_device is None:
+        raise DeviceUnavailable("Device not found")
+
+    self._client = BleakClient(ble_device)
+    await self._client.connect()
+    await self._client.start_notify(NOTIFY_CHAR_UUID, self._notification_handler)
+```
+
+## ESPHome Proxies
+
+**No special handling needed.** The `async_ble_device_from_address()` function
+transparently routes through ESPHome Bluetooth proxies. If the device is reachable
+via a proxy, HA will use it automatically.
+
+## Frame Format
+
+Many BLE devices use a framing protocol:
+
+```python
+def encode_frame(cmd: int, payload: bytes) -> bytes:
+    """Encode a command frame."""
+    data_len = len(payload)
+    frame = bytearray([
+        FRAME_START,     # e.g., 0xFA
+        FRAME_HEADER_1,  # e.g., 0xFC
+        FRAME_HEADER_2,  # e.g., 0xFD
+        cmd,
+        0x01,            # type
+        self._seq,       # sequence number
+        data_len,
+        0x00,
+        *payload,
+        FRAME_END,       # e.g., 0xFB
+    ])
+    return bytes(frame)
+```
+
+## Authentication
+
+Some devices require authentication per-connection:
+
+1. Request a challenge from the device
+2. Compute a response (often using a shared secret)
+3. Send the response; verify acknowledgment
+4. Optionally sync device time
+
+**Store the secret** in `config_entry.data`, not in code:
+
+```python
+secret = entry.data.get(CONF_SECRET)
+if secret:
+    await client.authenticate(bytes.fromhex(secret))
+```
+
+## Send and Wait Pattern
+
+For request-response protocols, use an `asyncio.Event`:
+
+```python
+async def _send_and_wait(self, cmd: int, payload: bytes) -> bytes | None:
+    """Send command and wait for response."""
+    self._response_event.clear()
+    self._expected_cmd = cmd
+    await self._client.write_gatt_char(WRITE_CHAR_UUID, frame)
+
+    try:
+        await asyncio.wait_for(self._response_event.wait(), timeout=5.0)
+    except TimeoutError:
+        return None
+
+    return self._response_data
+```
+
+**Important:** Verify the response command matches the request to avoid
+processing unsolicited notifications as responses.
+
+## BLE-Specific Anti-Patterns
+
+| Anti-pattern | Correct approach |
+|---|---|
+| Holding BLE connection open between polls | Connect, poll, disconnect (saves battery) |
+| Concurrent GATT operations | Use `asyncio.Lock()` for serial access |
+| Ignoring `BleakError` subtypes | Handle `BleakDeviceNotFoundError`, `BleakDBusError` |
+| Large payload without MTU check | Negotiate MTU or fragment writes |
+| Using actual device ID for auth when it should be zeroed | Check protocol docs — some devices require fixed auth bytes |

--- a/.agents/skills/home-assistant-integration-developer/references/ble-integration-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/ble-integration-guide.md
@@ -44,7 +44,7 @@ via a proxy, HA will use it automatically.
 Many BLE devices use a framing protocol:
 
 ```python
-def encode_frame(cmd: int, payload: bytes) -> bytes:
+def encode_frame(cmd: int, seq: int, payload: bytes) -> bytes:
     """Encode a command frame."""
     data_len = len(payload)
     frame = bytearray([
@@ -53,7 +53,7 @@ def encode_frame(cmd: int, payload: bytes) -> bytes:
         FRAME_HEADER_2,  # e.g., 0xFD
         cmd,
         0x01,            # type
-        self._seq,       # sequence number
+        seq,             # sequence number
         data_len,
         0x00,
         *payload,

--- a/.agents/skills/home-assistant-integration-developer/references/code-quality.md
+++ b/.agents/skills/home-assistant-integration-developer/references/code-quality.md
@@ -1,0 +1,136 @@
+# Code Quality Guide
+
+## Type Hints
+
+Every function must have type annotations:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable
+
+def calculate_filter_days(
+    filter_pct: int,
+    mode: int,
+    on_time: float,
+    off_time: float,
+) -> int:
+    """Calculate remaining filter days."""
+    ...
+```
+
+## Imports
+
+Correct import sources (Python 3.12+):
+
+```python
+# ✅ Correct
+from collections.abc import Callable, Coroutine, Mapping, Sequence
+from typing import Any, TypeVar
+
+# ❌ Wrong (ruff UP035)
+from typing import Callable, Dict, List, Optional, Tuple
+```
+
+Use `X | None` instead of `Optional[X]`:
+
+```python
+# ✅ Correct
+def get_value(data: MyData) -> float | None:
+
+# ❌ Wrong
+def get_value(data: MyData) -> Optional[float]:
+```
+
+## Ruff
+
+Ruff is the standard linter. Run before every commit:
+
+```bash
+ruff check custom_components/
+ruff format --check custom_components/
+```
+
+Auto-fix formatting:
+```bash
+ruff format custom_components/
+```
+
+Key ruff rules:
+- `UP035`: Use `collections.abc` for `Callable`, etc.
+- `UP007`: Use `X | Y` union syntax
+- Line length: typically 88-120 chars (configured in `pyproject.toml`)
+
+## Struct Packing
+
+Use unsigned format for device IDs:
+
+```python
+# ✅ Correct — unsigned, handles full 64-bit range
+struct.pack(">Q", device_id)
+
+# ❌ Wrong — signed, raises error for IDs with high bit set
+struct.pack(">q", device_id)
+```
+
+## Logging
+
+Use `_LOGGER` with appropriate levels:
+
+```python
+_LOGGER = logging.getLogger(__name__)
+
+# Debug: protocol details, raw data
+_LOGGER.debug("Received frame: cmd=%d data=%s", cmd, data.hex())
+
+# Info: significant state changes
+_LOGGER.info("Device authenticated successfully")
+
+# Warning: recoverable issues
+_LOGGER.warning("Invalid stored secret, re-initializing")
+
+# Error: unrecoverable issues (usually followed by UpdateFailed)
+_LOGGER.error("Failed to connect after 3 retries")
+```
+
+## Testing
+
+Test structure:
+```
+tests/
+├── __init__.py
+├── conftest.py        # Shared fixtures
+├── test_protocol.py   # Protocol encode/decode tests
+├── test_data_model.py # Data model property tests
+└── test_config_flow.py # Config flow tests (if applicable)
+```
+
+Run tests:
+```bash
+python -m pytest tests/ -v
+```
+
+Use `pytest` with `unittest.mock` for mocking HA components:
+
+```python
+from unittest.mock import AsyncMock, patch
+
+async def test_coordinator_update():
+    """Test coordinator fetches data."""
+    client = AsyncMock()
+    client.async_get_data.return_value = MyDataClass(...)
+    coordinator = MyCoordinator(hass, client)
+    await coordinator.async_refresh()
+    assert coordinator.data.temperature == 25.0
+```
+
+## Conventional Commits
+
+```
+feat: add LED brightness control
+fix: correct filter days calculation for smart mode
+docs: update README with CTW3 setup instructions
+refactor: extract payload builders to protocol.py
+ci: add ruff format check to lint workflow
+chore: bump manifest version to 1.3.0
+```

--- a/.agents/skills/home-assistant-integration-developer/references/config-flow-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/config-flow-guide.md
@@ -42,7 +42,7 @@ async def async_step_bluetooth(
 ) -> ConfigFlowResult:
     """Handle bluetooth discovery."""
     await self.async_set_unique_id(
-        dr.format_mac(discovery_info.address)
+        discovery_info.address.upper()
     )
     self._abort_if_unique_id_configured()
 
@@ -63,7 +63,7 @@ async def async_step_user(self, user_input=None):
     errors = {}
     if user_input is not None:
         address = user_input[CONF_ADDRESS]
-        await self.async_set_unique_id(dr.format_mac(address))
+        await self.async_set_unique_id(address.upper())
         self._abort_if_unique_id_configured()
 
         # Validate connection if needed

--- a/.agents/skills/home-assistant-integration-developer/references/config-flow-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/config-flow-guide.md
@@ -1,0 +1,150 @@
+# Config Flow Guide
+
+## Overview
+
+Config flows handle user setup and device discovery. They run in `config_flow.py` and
+inherit from `ConfigFlow`.
+
+```python
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigFlow
+from .const import DOMAIN
+
+class MyConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow for My Integration."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle a user-initiated config flow."""
+        ...
+```
+
+## Unique ID
+
+**Always set a unique ID** before creating a config entry:
+
+```python
+await self.async_set_unique_id(formatted_address)
+self._abort_if_unique_id_configured()
+```
+
+This prevents duplicate entries for the same device.
+
+## Bluetooth Discovery
+
+For BLE integrations, implement `async_step_bluetooth()`:
+
+```python
+async def async_step_bluetooth(
+    self, discovery_info: BluetoothServiceInfoBleak
+) -> ConfigFlowResult:
+    """Handle bluetooth discovery."""
+    await self.async_set_unique_id(
+        dr.format_mac(discovery_info.address)
+    )
+    self._abort_if_unique_id_configured()
+
+    self._discovery_info = discovery_info
+    return self.async_show_form(
+        step_id="bluetooth_confirm",
+        description_placeholders={"name": discovery_info.name},
+    )
+```
+
+## User Step
+
+For manual configuration:
+
+```python
+async def async_step_user(self, user_input=None):
+    """Handle a manual config entry."""
+    errors = {}
+    if user_input is not None:
+        address = user_input[CONF_ADDRESS]
+        await self.async_set_unique_id(dr.format_mac(address))
+        self._abort_if_unique_id_configured()
+
+        # Validate connection if needed
+        try:
+            await self._validate_device(address)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        else:
+            return self.async_create_entry(
+                title=user_input.get(CONF_NAME, "Device"),
+                data=user_input,
+            )
+
+    return self.async_show_form(
+        step_id="user",
+        data_schema=vol.Schema({
+            vol.Required(CONF_ADDRESS): str,
+            vol.Optional(CONF_NAME): str,
+        }),
+        errors=errors,
+    )
+```
+
+## Secrets
+
+**Never store secrets in source code.** Use config entry data:
+
+```python
+return self.async_create_entry(
+    title="My Device",
+    data={
+        CONF_ADDRESS: address,
+        CONF_SECRET: secret.hex(),  # Store as hex string
+    },
+)
+```
+
+Retrieve in coordinator/client:
+```python
+secret_hex = entry.data.get(CONF_SECRET, "")
+secret = bytes.fromhex(secret_hex) if secret_hex else None
+```
+
+Always wrap `bytes.fromhex()` in try/except for corrupted data resilience.
+
+## Options Flow
+
+For runtime configuration changes:
+
+```python
+class MyOptionsFlow(OptionsFlow):
+    """Options flow for My Integration."""
+
+    async def async_step_init(self, user_input=None):
+        """Handle options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=self.config_entry.options.get(CONF_SCAN_INTERVAL, 60),
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=600)),
+            }),
+        )
+```
+
+Register it in the config flow class:
+```python
+@staticmethod
+@callback
+def async_get_options_flow(config_entry):
+    return MyOptionsFlow()
+```
+
+## Abort Reasons
+
+Common abort reasons (define in strings.json):
+- `already_configured` — Device already set up
+- `already_in_progress` — Another flow for this device is active
+- `no_devices_found` — Scan found no compatible devices
+- `cannot_connect` — Connection to device failed

--- a/.agents/skills/home-assistant-integration-developer/references/coordinator-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/coordinator-guide.md
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed

--- a/.agents/skills/home-assistant-integration-developer/references/coordinator-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/coordinator-guide.md
@@ -1,0 +1,124 @@
+# Coordinator Guide
+
+## Setup Pattern
+
+The coordinator fetches data and is the single source of truth:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+class MyCoordinator(DataUpdateCoordinator[MyDataClass]):
+    """Coordinator for My Integration."""
+
+    def __init__(self, hass: HomeAssistant, client: MyClient) -> None:
+        """Initialize."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="My Integration",
+            update_interval=timedelta(seconds=60),
+        )
+        self.client = client
+        self._lock = asyncio.Lock()  # Serialize device access
+
+    async def _async_update_data(self) -> MyDataClass:
+        """Fetch data from device."""
+        async with self._lock:
+            try:
+                return await self.client.async_get_data()
+            except DeviceConnectionError as err:
+                raise UpdateFailed(f"Error communicating: {err}") from err
+```
+
+## Runtime Data
+
+**Use `entry.runtime_data`** (HA 2024.1+), not `hass.data[DOMAIN]`:
+
+```python
+# __init__.py
+type MyConfigEntry = ConfigEntry[MyCoordinator]
+
+async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
+    """Set up from config entry."""
+    client = MyClient(entry.data[CONF_ADDRESS])
+    coordinator = MyCoordinator(hass, client)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+```
+
+Benefits over `hass.data`:
+- Type-safe (generic ConfigEntry[T])
+- Automatic cleanup on unload
+- No manual dictionary management
+
+## Error Handling
+
+**Always** raise `UpdateFailed` from `_async_update_data()`:
+
+```python
+# ✅ Good
+try:
+    data = await self.client.fetch()
+except ConnectionError as err:
+    raise UpdateFailed(f"Connection failed: {err}") from err
+
+# ❌ Bad — swallows the error
+try:
+    data = await self.client.fetch()
+except Exception:
+    return self._last_data  # Silently fails
+```
+
+For specific errors, preserve the chain with `from err`.
+
+## Write Commands
+
+For command-style operations (e.g., turn on/off), go through the coordinator:
+
+```python
+async def async_send_command(self, cmd: int, payload: bytes) -> None:
+    """Send command to device."""
+    async with self._lock:
+        await self.client.send(cmd, payload)
+    await self.async_request_refresh()  # Refresh state after command
+```
+
+Entities call: `await self.coordinator.async_send_command(CMD_POWER, payload)`
+
+## Locking
+
+Use `asyncio.Lock()` for any device that requires serial access:
+
+```python
+self._lock = asyncio.Lock()
+
+async def _async_update_data(self):
+    async with self._lock:
+        # Only one operation at a time
+        return await self.client.fetch()
+```
+
+This is critical for BLE devices which can only handle one GATT operation at a time.
+
+## Resilient Data Handling
+
+Always handle corrupted stored data gracefully:
+
+```python
+# ✅ Good
+try:
+    secret = bytes.fromhex(entry.data.get(CONF_SECRET, ""))
+except ValueError:
+    _LOGGER.warning("Invalid stored secret, re-initializing")
+    secret = None
+```

--- a/.agents/skills/home-assistant-integration-developer/references/entity-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/entity-guide.md
@@ -119,7 +119,7 @@ def native_value(self):
 # ❌ Bad — network I/O in property
 @property
 def native_value(self):
-    return await self.client.fetch_temperature()  # NEVER DO THIS
+    return self.client.fetch_temperature()  # NEVER DO THIS
 ```
 
 ## State Classes

--- a/.agents/skills/home-assistant-integration-developer/references/entity-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/entity-guide.md
@@ -1,0 +1,158 @@
+# Entity Guide
+
+## Base Entity
+
+All entities inherit from a base `CoordinatorEntity` subclass:
+
+```python
+from __future__ import annotations
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+
+class MyBaseEntity(CoordinatorEntity[MyCoordinator]):
+    """Base entity for My Integration."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: MyCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.address)},
+            name=coordinator.device_name,
+            manufacturer="Manufacturer",
+            model=coordinator.model,
+        )
+```
+
+## Entity Descriptions
+
+Use frozen dataclasses with callable extractors:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+@dataclass(frozen=True, kw_only=True)
+class MySensorDescription(SensorEntityDescription):
+    """Sensor description with value extractor."""
+
+    value_fn: Callable[[MyDataClass], float | str | None]
+    available_fn: Callable[[MyDataClass], bool] = lambda _: True
+```
+
+**Why frozen?** Descriptions are shared across all instances of an entity type.
+Mutable state would cause bugs.
+
+Define descriptions as a tuple:
+
+```python
+SENSOR_DESCRIPTIONS: tuple[MySensorDescription, ...] = (
+    MySensorDescription(
+        key="temperature",
+        translation_key="temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.temperature,
+    ),
+)
+```
+
+## Platform Setup
+
+```python
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        MySensor(coordinator, desc)
+        for desc in SENSOR_DESCRIPTIONS
+        if desc.available_fn(coordinator.data)  # Only add relevant entities
+    )
+```
+
+## Unique ID
+
+Format: `{normalized_address}_{key}`
+
+```python
+self._attr_unique_id = f"{coordinator.address}_{description.key}"
+```
+
+Use `dr.format_mac()` to normalize MAC addresses.
+
+## Availability
+
+Entity is available when coordinator has data:
+
+```python
+@property
+def available(self) -> bool:
+    """Return True if entity is available."""
+    return super().available and self.entity_description.available_fn(
+        self.coordinator.data
+    )
+```
+
+## Properties Must Be O(1)
+
+Entity properties must only extract from `coordinator.data`:
+
+```python
+# ✅ Good — O(1) data extraction
+@property
+def native_value(self):
+    return self.entity_description.value_fn(self.coordinator.data)
+
+# ❌ Bad — network I/O in property
+@property
+def native_value(self):
+    return await self.client.fetch_temperature()  # NEVER DO THIS
+```
+
+## State Classes
+
+| Class | Use when |
+|---|---|
+| `MEASUREMENT` | Value is a point-in-time reading (temperature, humidity) |
+| `TOTAL` | Monotonically increasing total that can reset (energy meter) |
+| `TOTAL_INCREASING` | Monotonically increasing, HA auto-detects resets |
+
+**Caution with `TOTAL_INCREASING`**: Only use when the device persists the counter.
+If the counter resets on power cycle / reconnect, use `MEASUREMENT` or persist with
+`RestoreEntity`.
+
+## Device Info
+
+One `DeviceInfo` per physical device. All entities for the same device share identifiers:
+
+```python
+DeviceInfo(
+    identifiers={(DOMAIN, address)},
+    connections={(dr.CONNECTION_BLUETOOTH, address)},  # For BLE
+    name="My Device",
+    manufacturer="Manufacturer",
+    model="Model Name",
+    sw_version=coordinator.firmware_version,
+)
+```
+
+## Platform Reference
+
+| Platform | Entity base | Description base | Use case |
+|---|---|---|---|
+| `sensor` | `SensorEntity` | `SensorEntityDescription` | Read-only values |
+| `binary_sensor` | `BinarySensorEntity` | `BinarySensorEntityDescription` | On/off states |
+| `switch` | `SwitchEntity` | `SwitchEntityDescription` | On/off controls |
+| `button` | `ButtonEntity` | `ButtonEntityDescription` | Fire-and-forget actions |
+| `number` | `NumberEntity` | `NumberEntityDescription` | Numeric settings (min/max/step) |
+| `select` | `SelectEntity` | `SelectEntityDescription` | Dropdown choices |
+| `time` | `TimeEntity` | `TimeEntityDescription` | Time-of-day settings |

--- a/.agents/skills/home-assistant-integration-developer/references/entity-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/entity-guide.md
@@ -84,7 +84,11 @@ async def async_setup_entry(
 Format: `{normalized_address}_{key}`
 
 ```python
-self._attr_unique_id = f"{coordinator.address}_{description.key}"
+from homeassistant.helpers import device_registry as dr
+
+self._attr_unique_id = (
+    f"{dr.format_mac(coordinator.address)}_{description.key}"
+)
 ```
 
 Use `dr.format_mac()` to normalize MAC addresses.

--- a/.agents/skills/home-assistant-integration-developer/references/manifest-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/manifest-guide.md
@@ -1,0 +1,61 @@
+# Manifest Guide
+
+## Required Fields
+
+Every `manifest.json` must include:
+
+| Field | Type | Description |
+|---|---|---|
+| `domain` | string | Unique identifier, snake_case, matches folder name |
+| `name` | string | Human-readable name |
+| `version` | string | Semantic version (e.g., `1.2.3`) |
+| `config_flow` | boolean | `true` if integration has a config flow |
+| `documentation` | string | URL to documentation |
+| `requirements` | list | PyPI packages needed (e.g., `["bleak>=0.21.1"]`) |
+| `dependencies` | list | Other HA integrations required |
+| `codeowners` | list | GitHub usernames (e.g., `["@username"]`) |
+| `iot_class` | string | How the integration communicates |
+
+## IoT Class
+
+| Value | Description |
+|---|---|
+| `local_polling` | Local device, integration polls for data |
+| `local_push` | Local device, device pushes data |
+| `cloud_polling` | Cloud API, integration polls |
+| `cloud_push` | Cloud API, cloud pushes data |
+| `assumed_state` | No feedback from device, state is assumed |
+
+## Bluetooth Matchers
+
+For BLE integrations, add `bluetooth` key with matchers:
+
+```json
+{
+  "bluetooth": [
+    {
+      "connectable": true,
+      "local_name": "CTW3*"
+    }
+  ],
+  "dependencies": ["bluetooth", "bluetooth_adapters"]
+}
+```
+
+Matcher fields:
+- `local_name`: BLE advertised name (supports `*` wildcard at end)
+- `service_uuid`: GATT service UUID
+- `manufacturer_id`: Bluetooth manufacturer ID
+- `manufacturer_data_start`: First bytes of manufacturer data (hex)
+- `connectable`: Whether device must be connectable
+
+Multiple matchers can be provided as an array — any match triggers discovery.
+
+## Dependencies
+
+Common dependencies for BLE integrations:
+```json
+"dependencies": ["bluetooth", "bluetooth_adapters"]
+```
+
+This enables HA's Bluetooth stack including ESPHome proxy support.

--- a/.agents/skills/home-assistant-integration-developer/references/manifest-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/manifest-guide.md
@@ -2,7 +2,7 @@
 
 ## Required Fields
 
-Every `manifest.json` must include:
+For a Home Assistant custom integration, `manifest.json` should include these required fields:
 
 | Field | Type | Description |
 |---|---|---|
@@ -11,10 +11,18 @@ Every `manifest.json` must include:
 | `version` | string | Semantic version (e.g., `1.2.3`) |
 | `config_flow` | boolean | `true` if integration has a config flow |
 | `documentation` | string | URL to documentation |
-| `requirements` | list | PyPI packages needed (e.g., `["bleak>=0.21.1"]`) |
-| `dependencies` | list | Other HA integrations required |
 | `codeowners` | list | GitHub usernames (e.g., `["@username"]`) |
 | `iot_class` | string | How the integration communicates |
+
+## Common Optional Fields
+
+These fields are optional in Home Assistant manifests, but are often used depending on the integration:
+
+| Field | Type | Description |
+|---|---|---|
+| `requirements` | list | PyPI packages needed when the integration depends on external Python libraries (e.g., `["bleak>=0.21.1"]`) |
+| `dependencies` | list | Other HA integrations required for setup or runtime |
+| `bluetooth` | list | Bluetooth matchers used for BLE discovery |
 
 ## IoT Class
 

--- a/.agents/skills/home-assistant-integration-developer/references/translations-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/translations-guide.md
@@ -2,8 +2,12 @@
 
 ## strings.json
 
-`strings.json` is the **source of truth** for all user-visible text. It uses English as
-the base language and follows this structure:
+`strings.json` defines the base English structure for shared translation content such as
+config flows, options flows, errors, and abort reasons. In this repository, entity names
+are currently stored in `translations/en.json` and mirrored to the other files in
+`translations/`, rather than being defined in `strings.json`.
+
+Example `strings.json` structure:
 
 ```json
 {
@@ -29,24 +33,13 @@ the base language and follows this structure:
       "cannot_connect": "Failed to connect",
       "unknown": "Unexpected error"
     }
-  },
-  "entity": {
-    "sensor": {
-      "filter_percent": {
-        "name": "Filter life"
-      },
-      "pump_runtime_today": {
-        "name": "Pump runtime today"
-      }
-    },
-    "switch": {
-      "power": {
-        "name": "Power"
-      }
-    }
   }
 }
 ```
+
+If you want `strings.json` to be the single source of truth for entity names too, you must
+explicitly duplicate the `entity.<platform>.<key>.name` keys there and keep them in sync
+with `translations/*.json`.
 
 ## Translation Keys
 
@@ -60,7 +53,8 @@ MySensorDescription(
 )
 ```
 
-The `translation_key` maps to `strings.json` → `entity.<platform>.<key>.name`.
+For entity names in this repository, the `translation_key` maps to
+`translations/<language>.json` → `entity.<platform>.<key>.name`.
 
 ## Entity Names
 
@@ -80,21 +74,26 @@ Options flow strings go under `options`.
 When adding a new entity:
 
 1. Add the description to the platform file with `translation_key`
-2. Add the name to `strings.json` under `entity.<platform>.<key>.name`
-3. Mirror to all files in `translations/` (en.json, nl.json, uk.json, etc.)
+2. Add the name to `translations/en.json` under `entity.<platform>.<key>.name`
+3. Mirror the key to all other files in `translations/` (nl.json, uk.json, etc.)
 4. Translate the name for each language file
+5. If you want `strings.json` to remain the single source of truth, also duplicate the
+   same entity key there and keep both locations in sync
 
 ## Translation Files
 
-Files in `translations/` mirror the structure of `strings.json`:
+Files in `translations/` contain the runtime language data used by Home Assistant:
 
 ```
 translations/
-├── en.json    # English (should match strings.json)
+├── en.json    # English
 ├── nl.json    # Dutch
 ├── uk.json    # Ukrainian
 └── ...
 ```
 
-Keep all translation files in sync. When adding keys to `strings.json`,
-add corresponding keys to all translation files.
+In this repository, config-flow strings should stay aligned with `strings.json`, while
+entity translations may live directly in `translations/*.json`.
+
+Keep all translation files in sync. When adding entity keys to `translations/en.json`,
+add corresponding keys to all other translation files as well.

--- a/.agents/skills/home-assistant-integration-developer/references/translations-guide.md
+++ b/.agents/skills/home-assistant-integration-developer/references/translations-guide.md
@@ -1,0 +1,100 @@
+# Translations Guide
+
+## strings.json
+
+`strings.json` is the **source of truth** for all user-visible text. It uses English as
+the base language and follows this structure:
+
+```json
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configure Device",
+        "description": "Enter the BLE address of your device.",
+        "data": {
+          "address": "Bluetooth address",
+          "name": "Device name"
+        }
+      },
+      "bluetooth_confirm": {
+        "description": "Confirm setup of {name}"
+      }
+    },
+    "abort": {
+      "already_configured": "Device already configured",
+      "cannot_connect": "Unable to connect to device"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "unknown": "Unexpected error"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "filter_percent": {
+        "name": "Filter life"
+      },
+      "pump_runtime_today": {
+        "name": "Pump runtime today"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    }
+  }
+}
+```
+
+## Translation Keys
+
+Entity names are resolved via `translation_key`:
+
+```python
+MySensorDescription(
+    key="filter_percent",
+    translation_key="filter_percent",
+    ...
+)
+```
+
+The `translation_key` maps to `strings.json` → `entity.<platform>.<key>.name`.
+
+## Entity Names
+
+With `_attr_has_entity_name = True`, the entity's display name is:
+`<Device Name> <Entity Name from translation>`
+
+Example: If device is "Petkit CTW3" and entity translation is "Filter life",
+the entity shows as "Petkit CTW3 Filter life".
+
+## Config Flow Strings
+
+Config flow steps, errors, and abort reasons are under the `config` key.
+Options flow strings go under `options`.
+
+## Adding New Entities
+
+When adding a new entity:
+
+1. Add the description to the platform file with `translation_key`
+2. Add the name to `strings.json` under `entity.<platform>.<key>.name`
+3. Mirror to all files in `translations/` (en.json, nl.json, uk.json, etc.)
+4. Translate the name for each language file
+
+## Translation Files
+
+Files in `translations/` mirror the structure of `strings.json`:
+
+```
+translations/
+├── en.json    # English (should match strings.json)
+├── nl.json    # Dutch
+├── uk.json    # Ukrainian
+└── ...
+```
+
+Keep all translation files in sync. When adding keys to `strings.json`,
+add corresponding keys to all translation files.


### PR DESCRIPTION
This pull request introduces a comprehensive skill guide for developing Home Assistant custom integrations, along with detailed reference guides on BLE integration, config flow patterns, coordinator usage, and code quality. The main goal is to standardize best practices, prevent common mistakes, and provide ready-to-use reference material for developers working on Home Assistant custom components.

The most important changes are:

**Skill Documentation and Best Practices**

* Added `.agents/skills/home-assistant-integration-developer/SKILL.md` outlining best practices, anti-patterns, and a decision workflow for Home Assistant custom integration development, including guidance on config flows, coordinators, BLE protocols, translation handling, and code quality.

**Reference Guides**

* Added `references/ble-integration-guide.md` with step-by-step instructions for implementing BLE integrations, including connection patterns, frame encoding, authentication, and anti-patterns specific to BLE and Bluetooth proxies.
* Added `references/config-flow-guide.md` detailing how to implement robust config flows and options flows, handle secrets securely, and prevent duplicate device entries, with code examples for both user-initiated and Bluetooth-based flows.
* Added `references/coordinator-guide.md` describing the correct use of `DataUpdateCoordinator`, the modern `entry.runtime_data` pattern, error handling, command execution, and concurrency control with locks.
* Added `references/code-quality.md` covering type hints, import conventions, struct packing, logging, test structure, and conventional commit messages to ensure maintainable and idiomatic Python code.