### PR TITLE
chore: bump version to 1.1.4

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
Bump version to 1.1.4 for the next release.

Changes included since v1.1.3:
- fix: Remove incorrect SensorDeviceClass.BATTERY from filter_percent sensor
- feat: Add battery_work_seconds and battery_sleep_seconds number entities (CTW3)
- fix: Remove duplicate options keys in translation files
- docs: Add battery interval section to dashboard YAML