### PR TITLE
Release v1.1.4

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/number.py
+++ b/custom_components/petkit_ble/number.py
@@ -1,4 +1,4 @@
-"""Number platform for Petkit BLE (smart mode timers and LED brightness)."""
+"""Number platform for Petkit BLE (smart mode timers, LED brightness, battery intervals)."""
 
 from __future__ import annotations
 
@@ -24,6 +24,7 @@ class PetkitNumberDescription(NumberEntityDescription):
     """Number description with value extractor and setter field name."""
 
     value_fn: Callable[[PetkitFountainData], float | None]
+    available_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     field_name: str
 
 
@@ -58,6 +59,28 @@ NUMBER_DESCRIPTIONS: tuple[PetkitNumberDescription, ...] = (
         value_fn=lambda d: d.led_brightness,
         field_name="led_brightness",
     ),
+    PetkitNumberDescription(
+        key="battery_work_seconds",
+        translation_key="battery_work_seconds",
+        native_min_value=1,
+        native_max_value=3600,
+        native_step=1,
+        mode=NumberMode.BOX,
+        value_fn=lambda d: d.battery_work_time,
+        available_fn=lambda d: d.is_ctw3,
+        field_name="battery_work_time",
+    ),
+    PetkitNumberDescription(
+        key="battery_sleep_seconds",
+        translation_key="battery_sleep_seconds",
+        native_min_value=1,
+        native_max_value=7200,
+        native_step=1,
+        mode=NumberMode.BOX,
+        value_fn=lambda d: d.battery_sleep_time,
+        available_fn=lambda d: d.is_ctw3,
+        field_name="battery_sleep_time",
+    ),
 )
 
 
@@ -84,6 +107,13 @@ class PetkitBleNumber(PetkitBleEntity, NumberEntity):
         """Initialise the number entity."""
         super().__init__(coordinator, description.key)
         self.entity_description = description
+
+    @property
+    def available(self) -> bool:
+        """Return True only when data is present and the device supports this entity."""
+        if not super().available:
+            return False
+        return self.entity_description.available_fn(self.coordinator.data)
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -44,7 +44,6 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         key="filter_percent",
         translation_key="filter_percent",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda d: d.filter_percent,
     ),

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -44,19 +44,6 @@
       }
     }
   },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Petkit BLE Options",
-        "data": {
-          "debug": "Enable debug logging"
-        },
-        "data_description": {
-          "debug": "Log every BLE frame (TX/RX) and authentication step. Useful for diagnosing connection issues. Disable in production."
-        }
-      }
-    }
-  },
   "entity": {
     "sensor": {
       "filter_percent": {"name": "Filter Life"},
@@ -90,7 +77,9 @@
     "number": {
       "smart_work_minutes": {"name": "Smart Mode Work Time"},
       "smart_sleep_minutes": {"name": "Smart Mode Sleep Time"},
-      "led_brightness": {"name": "LED Brightness"}
+      "led_brightness": {"name": "LED Brightness"},
+      "battery_work_seconds": {"name": "Battery Work Duration"},
+      "battery_sleep_seconds": {"name": "Battery Sleep Duration"}
     },
     "time": {
       "led_on_time": {"name": "LED On Time"},

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -44,19 +44,6 @@
       }
     }
   },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Petkit BLE opties",
-        "data": {
-          "debug": "Debug-logging inschakelen"
-        },
-        "data_description": {
-          "debug": "Log elk BLE-frame (TX/RX) en elke authenticatiestap. Handig voor het diagnosticeren van verbindingsproblemen. Schakel uit in productie."
-        }
-      }
-    }
-  },
   "entity": {
     "sensor": {
       "filter_percent": {"name": "Filterlevensduur"},
@@ -90,7 +77,9 @@
     "number": {
       "smart_work_minutes": {"name": "Smart-modus werktijd"},
       "smart_sleep_minutes": {"name": "Smart-modus slaaptijd"},
-      "led_brightness": {"name": "LED-helderheid"}
+      "led_brightness": {"name": "LED-helderheid"},
+      "battery_work_seconds": {"name": "Batterij werkduur"},
+      "battery_sleep_seconds": {"name": "Batterij slaaptijd"}
     },
     "time": {
       "led_on_time": {"name": "LED aan-tijd"},

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -44,19 +44,6 @@
       }
     }
   },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Параметри Petkit BLE",
-        "data": {
-          "debug": "Увімкнути журналювання налагодження"
-        },
-        "data_description": {
-          "debug": "Записувати кожен BLE-кадр (TX/RX) та крок автентифікації. Корисно для діагностики проблем із підключенням. Вимкніть у виробничому середовищі."
-        }
-      }
-    }
-  },
   "entity": {
     "sensor": {
       "filter_percent": {"name": "Ресурс фільтра"},
@@ -90,7 +77,9 @@
     "number": {
       "smart_work_minutes": {"name": "Час роботи смарт-режиму"},
       "smart_sleep_minutes": {"name": "Час сну смарт-режиму"},
-      "led_brightness": {"name": "Яскравість LED"}
+      "led_brightness": {"name": "Яскравість LED"},
+      "battery_work_seconds": {"name": "Тривалість роботи від батареї"},
+      "battery_sleep_seconds": {"name": "Тривалість сну від батареї"}
     },
     "time": {
       "led_on_time": {"name": "Час увімкнення LED"},

--- a/docs/dashboard.yaml
+++ b/docs/dashboard.yaml
@@ -172,6 +172,14 @@ views:
               - entity: time.petkit_ctw3_100_dnd_end_time
                 name: DND End
 
+          - type: entities
+            title: Battery Mode Interval
+            entities:
+              - entity: number.petkit_ctw3_100_battery_work_seconds
+                name: Work Duration (sec)
+              - entity: number.petkit_ctw3_100_battery_sleep_seconds
+                name: Sleep Duration (sec)
+
       # ── Device Info ──────────────────────────────────────────────────
       - title: Device Info
         type: grid


### PR DESCRIPTION
## Release v1.1.4

### Changes since v1.1.3
- **Bug fix:** Remove incorrect \SensorDeviceClass.BATTERY\ from \ilter_percent\ sensor (wrong icon/category)
- **New feature:** Add \attery_work_seconds\ and \attery_sleep_seconds\ number entities (CTW3-only) — configurable battery mode intervals per the manual
- **Infrastructure:** Add \vailable_fn\ support to number entity descriptions
- **Translations:** Add new entity names (en, nl, uk) + fix duplicate \options\ keys in all translation files
- **Dashboard:** Add Battery Mode Interval section to \docs/dashboard.yaml\

### Manual compliance
These changes address gaps found by comparing the codebase against the Petkit EVERSWEET MAX 2 (P4116/CTW3) user manual.

Closes #43