### PR TITLE
fix: improve BLE proxy reachability with diagnostics and grace window

### DIFF
--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -4,13 +4,24 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from homeassistant.components.bluetooth import async_ble_device_from_address, async_last_service_info
+from homeassistant.components.bluetooth import (
+    BluetoothChange,
+    BluetoothScanningMode,
+    async_ble_device_from_address,
+    async_last_service_info,
+    async_register_callback,
+    async_scanner_count,
+)
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
+    from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -18,6 +29,12 @@ from .ble_client import PetkitBleClient, PetkitFountainData
 from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long to wait for a connectable advertisement before giving up. The proxy
+# emits adverts every ~500ms, but it can be unavailable for a few seconds while
+# it is mid-connect to another device. A 15s grace window covers that case
+# without significantly delaying genuine "device powered off" failures.
+CONNECTABLE_WAIT_TIMEOUT = 15.0
 
 
 class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
@@ -50,17 +67,130 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             update_interval=timedelta(seconds=POLL_INTERVAL),
         )
 
-    def _get_ble_device(self) -> PetkitBleClient | None:
-        """Return a BLE client for the fountain, or None if not reachable."""
-        ble_device = async_ble_device_from_address(self.hass, self._address, connectable=True)
-        if ble_device is None:
+    def _log_unreachable_diagnostics(self) -> None:
+        """Emit a single diagnostic log line explaining why the device is not connectable.
+
+        Distinguishes between "no scanner has ever seen the device" (likely off
+        or out of range) and "device is advertising but no connectable path is
+        currently available" (proxy slot busy / non-connectable scanner only).
+        """
+        try:
+            scanner_count_total = async_scanner_count(self.hass, connectable=False)
+            scanner_count_conn = async_scanner_count(self.hass, connectable=True)
+        except Exception:  # diagnostics must never raise
+            scanner_count_total = scanner_count_conn = -1
+
+        last_any = async_last_service_info(self.hass, self._address, connectable=False)
+        last_conn = async_last_service_info(self.hass, self._address, connectable=True)
+
+        if last_any is None:
+            _LOGGER.warning(
+                "%s (%s) is not advertising on any of %d scanner(s) "
+                "(connectable scanners: %d). Device may be powered off or out of range.",
+                self._name,
+                self._address,
+                scanner_count_total,
+                scanner_count_conn,
+            )
+            return
+
+        now = time.monotonic()
+        age_any = now - last_any.time if last_any.time else 0.0
+
+        if last_conn is None:
+            _LOGGER.warning(
+                "%s (%s) seen via %s (rssi=%s, %.1fs ago) but no connectable scanner "
+                "currently has it (%d connectable / %d total scanners). "
+                "Proxy slot may be busy or the advert was not connectable.",
+                self._name,
+                self._address,
+                last_any.source,
+                last_any.rssi,
+                age_any,
+                scanner_count_conn,
+                scanner_count_total,
+            )
+        else:
+            age_conn = now - last_conn.time if last_conn.time else 0.0
+            _LOGGER.warning(
+                "%s (%s) connectable advert seen via %s (rssi=%s, %.1fs ago) "
+                "but async_ble_device_from_address returned None. "
+                "Likely a transient HA bluetooth state.",
+                self._name,
+                self._address,
+                last_conn.source,
+                last_conn.rssi,
+                age_conn,
+            )
+
+    async def _wait_for_connectable_device(self, timeout: float) -> BLEDevice | None:
+        """Wait up to ``timeout`` seconds for a connectable advertisement.
+
+        Returns the resolved BLEDevice, or None if no connectable advertisement
+        is seen in time. Uses HA's bluetooth callback so we react as soon as a
+        new advert arrives instead of polling.
+
+        The callback is registered *before* the initial address lookup so we
+        cannot miss an advertisement that arrives between the lookup and the
+        registration.
+        """
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[None] = loop.create_future()
+
+        @callback
+        def _on_advertisement(
+            _service_info: BluetoothServiceInfoBleak,
+            _change: BluetoothChange,
+        ) -> None:
+            if not future.done():
+                future.set_result(None)
+
+        cancel = async_register_callback(
+            self.hass,
+            _on_advertisement,
+            {"address": self._address, "connectable": True},
+            BluetoothScanningMode.PASSIVE,
+        )
+        try:
+            # Re-check immediately after registration to close the race window
+            # between the caller's initial lookup and our callback being live.
+            device = async_ble_device_from_address(self.hass, self._address, connectable=True)
+            if device is not None:
+                return device
+
+            try:
+                await asyncio.wait_for(future, timeout)
+            except TimeoutError:
+                return None
+        finally:
+            cancel()
+
+        return async_ble_device_from_address(self.hass, self._address, connectable=True)
+
+    async def _get_ble_client(self) -> PetkitBleClient | None:
+        """Resolve the device and return a client, waiting briefly if needed.
+
+        Diagnostic warnings are only emitted on *final* failure, so transient
+        proxy contention that resolves within the grace window stays silent.
+        """
+        device = async_ble_device_from_address(self.hass, self._address, connectable=True)
+        if device is None:
+            _LOGGER.debug(
+                "%s (%s) not immediately connectable, waiting up to %.0fs for advertisement",
+                self._name,
+                self._address,
+                CONNECTABLE_WAIT_TIMEOUT,
+            )
+            device = await self._wait_for_connectable_device(CONNECTABLE_WAIT_TIMEOUT)
+        if device is None:
+            self._log_unreachable_diagnostics()
             return None
-        return PetkitBleClient(ble_device)
+        return PetkitBleClient(device)
 
     async def _async_update_data(self) -> PetkitFountainData:
         """Fetch the latest data from the fountain."""
         async with self._ble_lock:
-            client = self._get_ble_device()
+            client = await self._get_ble_client()
             if client is None:
                 raise UpdateFailed(f"Petkit fountain {self._name} ({self._address}) not reachable via Bluetooth")
             try:
@@ -95,7 +225,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         command failed.
         """
         async with self._ble_lock:
-            client = self._get_ble_device()
+            client = await self._get_ble_client()
             if client is None:
                 _LOGGER.warning(
                     "Cannot send CMD %d: %s (%s) not reachable via Bluetooth",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
## Problem

When `async_ble_device_from_address(connectable=True)` returned `None` (e.g. because the ESPHome BLE proxy was mid-connect to another device), the coordinator failed the poll immediately with `UpdateFailed` and waited a full 60 s before retrying. Result: spurious `Petkit fountain ... not reachable via Bluetooth` errors, even though the proxy successfully connects seconds later.

The proxy logs make this clear: at one moment the proxy logs `Connecting v3 with cache` -> `Connection open` -> notify cycle for `A4:C1:38:E6:2B:1C` and works perfectly, while at other moments the poll fails without any clear reason in HA logs.

## Solution

- **Event-driven grace window (15 s):** if the first lookup returns `None`, register an `async_register_callback` for the MAC with `connectable=True` and wait for the next advertisement. Adverts arrive every ~500 ms, so genuine successes resolve in well under a second; only truly absent devices wait the full 15 s.
- **Diagnostic logging on the unreachable path:** scanner counts, last-seen RSSI/source, age of last advert, and whether a connectable scanner currently has the device. Distinguishes three scenarios:
  - no scanner has ever seen the device -> powered off / out of range
  - only a non-connectable advert -> proxy slot busy
  - connectable advert seen recently but HA still returned `None` -> transient state, retry will succeed
- The same resolver is now used for `async_send_command` too, so button/switch actions no longer fail instantly during proxy contention.

Manifest version bumped to `1.0.2` so HACS / the release workflow can publish a new release.

## Testing

- `uv tool run ruff check custom_components/` OK
- `uv tool run ruff format --check custom_components/` OK
- No unit tests exist in this repo for the coordinator; functional testing in a live HA environment is recommended.