### PR TITLE
chore: require English for code, commits, PRs, and issues

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -221,7 +221,7 @@ Even as admin (bypassed protection), direct pushes skip CI and break the audit t
 
 ## Code Conventions
 
-- **Language**: All code comments, docstrings, commit messages, and documentation in **English**.
+- **Language**: All code, comments, docstrings, commit messages, PR titles & descriptions, and GitHub issues MUST be in **English**. This applies even when the user/contributor communicates in another language — only the chat reply to the user may be in their language; everything that lands in the repository or on GitHub is English.
 - **Python**: 3.12+, type hints required, `from __future__ import annotations` in every module.
 - **Imports**: Use `from collections.abc import Callable` (not `from typing import Callable`).
 - **Linter**: ruff — run `ruff check custom_components/` before committing.

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -14,6 +14,7 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **HA minimum:** 2024.1 — uses `entry.runtime_data`, `CoordinatorEntity`, `async_ble_device_from_address`
 - **Python:** 3.12+, `from __future__ import annotations` in every module, `collections.abc.Callable`
 - **Linter:** ruff — run `uv run ruff check custom_components/` before committing
+- **Language:** ALL code, comments, docstrings, commit messages, PR titles/descriptions, and GitHub issues MUST be written in English. No exceptions, even when the user writes in another language.
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
 
 ## BLE Frame Format


### PR DESCRIPTION
Make explicit in both .github/copilot-instructions.md and the petkit-ble skill instructions that all repository content and GitHub artefacts (commits, PR titles/descriptions, issues) must be in English, even when contributors communicate in another language. Only the chat reply to the user may follow the user's language.