### PR TITLE
fix(ctw3): always force power=1 on mode select (Smart->Normal)

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/protocol.py
+++ b/custom_components/petkit_ble/protocol.py
@@ -157,3 +157,21 @@ def build_ctw3_mode_payload(power: int, suspend: int, mode: int) -> list[int]:
     if power == 0:
         suspend = 0
     return [power, suspend, mode]
+
+
+def build_ctw3_select_mode_payload(mode: int) -> list[int]:
+    """Build a CMD 220 payload for a user mode-select on CTW3.
+
+    Selecting a mode in the HA UI always implies power=1: the user expects
+    that mode to *run*. We deliberately ignore the cached ``power_status``
+    here because byte[0] of CMD 210 can momentarily be reported as 0 while
+    the device is in smart-mode sleep cycle. Coupling the mode select to
+    that cached value caused Smart→Normal to silently send [0, 0, 1] and
+    leave the pump off.
+
+    Returns:
+      - Normal (mode=1): [1, 1, 1]  (power on, pump active)
+      - Smart  (mode=2): [1, 0, 2]  (power on, timer-managed)
+    """
+    suspend = 1 if mode == 1 else 0
+    return build_ctw3_mode_payload(1, suspend, mode)

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import CMD_SET_POWER_MODE
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
-from .protocol import build_change_mode_payload, build_ctw3_mode_payload
+from .protocol import build_change_mode_payload, build_ctw3_select_mode_payload
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,16 +62,21 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
         data = self.coordinator.data
 
         if data is not None and data.is_ctw3:
-            # CTW3: [power, suspend, mode] via protocol helper.
-            # suspend=1 activates the pump (normal mode); suspend=0 lets the
-            # device's internal timer manage cycling (smart mode).
-            power = data.power_status if data.power_status in (0, 1) else 1
-            suspend = 1 if mode_int == 1 and power == 1 else 0
-            payload = build_ctw3_mode_payload(power, suspend, mode_int)
+            # CTW3: payload [power, suspend, mode] is built by a dedicated
+            # helper that always forces power=1, because selecting a mode in
+            # HA implies the user wants that mode to run. See
+            # build_ctw3_select_mode_payload for the rationale.
+            payload = build_ctw3_select_mode_payload(mode_int)
         else:
             # Generic W5/CTW2: byte[0] = mode (1=normal, 2=smart); selecting a mode implies power-on
             payload = build_change_mode_payload(mode_int)
 
+        _LOGGER.info(
+            "Mode select -> %s (alias=%s): sending CMD 220 payload=%s",
+            option,
+            data.alias if data is not None else "unknown",
+            payload,
+        )
         success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, payload)
         if success:
             await self.coordinator.async_request_refresh()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -13,6 +13,7 @@ from custom_components.petkit_ble.const import (
 from custom_components.petkit_ble.protocol import (
     build_change_mode_payload,
     build_ctw3_mode_payload,
+    build_ctw3_select_mode_payload,
     build_init_payload,
     build_settings_payload_ctw3,
     build_settings_payload_generic,
@@ -166,6 +167,24 @@ class TestBuildModePayload:
         assert build_ctw3_mode_payload(1, 0, 2) == [1, 0, 2]
         # When power=0, suspend is forced to 0 regardless of the argument passed
         assert build_ctw3_mode_payload(0, 1, 1) == [0, 0, 1]
+
+
+class TestBuildCtw3SelectModePayload:
+    """Tests for build_ctw3_select_mode_payload (regression for issue #54).
+
+    Selecting a mode in HA must always send power=1, regardless of the cached
+    ``power_status``. Otherwise Smart->Normal can silently send [0, 0, 1] and
+    leave the pump off when byte[0] of CMD 210 was momentarily 0 during the
+    smart-mode sleep cycle.
+    """
+
+    def test_select_normal_always_sends_power_on_with_suspend(self) -> None:
+        """Selecting Normal => [1, 1, 1] (power on, pump active)."""
+        assert build_ctw3_select_mode_payload(1) == [1, 1, 1]
+
+    def test_select_smart_always_sends_power_on_without_suspend(self) -> None:
+        """Selecting Smart => [1, 0, 2] (power on, timer-managed)."""
+        assert build_ctw3_select_mode_payload(2) == [1, 0, 2]
 
 
 class TestFrameFormat:


### PR DESCRIPTION
Fixes the bug where switching from Smart -> Normal in HA does nothing on CTW3 fountains.

## Root cause

`select.py` was propagating `data.power_status` from the most recent CMD 210 into the CMD 220 payload. While in smart-mode sleep cycle, byte[0] of the state response can be reported as `0`, causing Smart -> Normal to send `[0, 0, 1]` instead of `[1, 1, 1]` and leaving the pump off.

## Fix

- Extracted `build_ctw3_select_mode_payload(mode)` in `protocol.py` that always forces `power=1` (Normal -> `[1, 1, 1]`, Smart -> `[1, 0, 2]`).
- `select.py` now uses the helper unconditionally for CTW3.
- Added INFO-level log of the CMD 220 payload for future troubleshooting.
- Added unit tests locking the invariant.
- Bumped manifest to 1.1.6.

## Verification

- `uv tool run ruff check` and `ruff format --check` pass.
- `pytest tests/test_protocol.py` -> 20 passed.

Closes #54