### PR TITLE
fix(select): demote CMD 220 payload log to DEBUG and document review/release workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -201,18 +201,36 @@ Every change — no matter how small — **must** follow these steps in order:
    git push -u origin fix/my-fix
    gh pr create --base dev --head fix/my-fix --title "..." --body "..."
    ```
-7. **CI** — Wait for all CI checks to pass (ruff lint, ruff format, HACS validation).
-8. **Review** — After CI passes, check the Copilot code review on the PR:
+7. **CI** — Wait for all CI checks to pass (ruff lint, ruff format, HACS validation,
+   and the "Request Copilot Code Review" workflow).
+8. **Review** — After CI passes, **wait for the Copilot code review to actually be
+   submitted** before merging. The "Request Copilot Code Review" workflow only
+   *triggers* the review; the review comments arrive asynchronously a short time
+   later. Verify the review has been submitted by polling:
+   ```
+   gh pr view <N> --json reviews -q '.reviews[] | select(.author.login=="copilot-pull-request-reviewer") | .submittedAt'
+   ```
+   (Or use the GitHub API `get_reviews` / `get_review_comments` methods.)
+   Only proceed when the review is present. Then:
    - Retrieve all review comments using the GitHub API / `gh` CLI.
    - If there are comments or suggestions, **fix them** in a new commit on the same branch.
    - Reply to each review thread explaining what was fixed.
    - **Resolve** all review threads (using GraphQL `resolveReviewThread` mutation).
-   - Push the fixes and wait for CI to pass again.
+   - Push the fixes and wait for CI to pass again, then re-check the review.
    - Repeat until there are no unresolved comments.
 9. **Merge** — Once CI passes and all review comments are resolved, merge the PR into `dev`:
    ```
    gh pr merge <PR_NUMBER> --squash --delete-branch
    ```
+10. **Verify dev pre-release** — After the merge, confirm that the `Pre-release`
+    workflow created a new `v<version>-dev.<timestamp>` tag/release on `dev`:
+    ```
+    gh run list --workflow pre-release.yml --limit 1
+    gh release list --limit 3
+    ```
+    If the workflow did not run or failed, investigate before moving on. This
+    pre-release is what HACS beta-testers install, so missing it silently breaks
+    their update path.
 
 **NEVER commit or push directly to `dev` or `main`.**  
 Even as admin (bypassed protection), direct pushes skip CI and break the audit trail.

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -16,6 +16,8 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **Linter:** ruff — run `uv run ruff check custom_components/` before committing
 - **Language:** ALL code, comments, docstrings, commit messages, PR titles/descriptions, and GitHub issues MUST be written in English. No exceptions, even when the user writes in another language.
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
+- **PR review gate:** Always wait for the Copilot code reviewer to *actually submit* its review (not just the workflow run to finish) before merging. The review comments arrive asynchronously after the "Request Copilot Code Review" workflow turns green. Verify with `gh pr view <N> --json reviews` and address every comment before merge.
+- **Post-merge:** After merging to `dev`, verify the `Pre-release` workflow produced a new `v<version>-dev.<timestamp>` GitHub release; this is what HACS beta-testers install.
 
 ## BLE Frame Format
 

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -71,7 +71,7 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
             # Generic W5/CTW2: byte[0] = mode (1=normal, 2=smart); selecting a mode implies power-on
             payload = build_change_mode_payload(mode_int)
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "Mode select -> %s (alias=%s): sending CMD 220 payload=%s",
             option,
             data.alias if data is not None else "unknown",


### PR DESCRIPTION
## Summary

Follow-up to PR #55. Two related changes:

1. **Address Copilot review on #55** — the new `CMD 220 payload` log in `select.py` was emitted at `INFO` on every mode change. Other protocol-level logs in this integration use `DEBUG` (e.g. `ble_client.py` TX/RX), so this aligns with the existing convention.
2. **Document the review/release workflow** — `.github/copilot-instructions.md` and `.github/instructions/petkit-ble.instructions.md` now make two things explicit:
   - Wait for the Copilot reviewer to **actually submit** its review (not just the `Request Copilot Code Review` workflow turning green) before merging.
   - After merging to `dev`, verify that the `Pre-release` workflow produced a new `v<version>-dev.<timestamp>` release (HACS beta path).

Also bumps version to `1.1.7`.

## Verification

- `ruff check` + `ruff format --check` clean.
- No behaviour change beyond the log level.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>