### PR TITLE
fix(ctw3): latch mode across smart-sleep so UI no longer flips to Normal

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -341,11 +341,12 @@ class PetkitBleClient:
         data.power_status = payload[0]
         data.suspend_status = payload[1]
         # The CTW3 firmware has been observed to transiently report mode=0 during
-        # the smart-mode sleep phase. Treating that as ground truth makes the
-        # mode select fall back to "normal" (see select.py) and any subsequent
-        # power-switch toggle then sends the wrong CMD 220 payload, kicking the
-        # device out of smart mode. We therefore only update ``mode`` when the
-        # new value is a known mode (1=normal, 2=smart). See issue #57.
+        # the smart-mode sleep phase. Treating that as ground truth would make
+        # the mode select show "Unknown" (it returns None for unknown values)
+        # and any subsequent power-switch toggle would read data.mode == 0/1,
+        # sending the wrong CMD 220 payload and kicking the device out of smart
+        # mode. We therefore only update ``mode`` when the new value is a known
+        # mode (1=normal, 2=smart). See issue #57.
         new_mode = payload[2]
         if new_mode in (1, 2):
             data.mode = new_mode

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -340,7 +340,21 @@ class PetkitBleClient:
             return
         data.power_status = payload[0]
         data.suspend_status = payload[1]
-        data.mode = payload[2]
+        # The CTW3 firmware has been observed to transiently report mode=0 during
+        # the smart-mode sleep phase. Treating that as ground truth makes the
+        # mode select fall back to "normal" (see select.py) and any subsequent
+        # power-switch toggle then sends the wrong CMD 220 payload, kicking the
+        # device out of smart mode. We therefore only update ``mode`` when the
+        # new value is a known mode (1=normal, 2=smart). See issue #57.
+        new_mode = payload[2]
+        if new_mode in (1, 2):
+            data.mode = new_mode
+        else:
+            _LOGGER.debug(
+                "CTW3 reported mode=%d; keeping latched mode=%d",
+                new_mode,
+                data.mode,
+            )
         data.electric_status = payload[3]
         data.dnd_state = payload[4]
         data.warning_breakdown = payload[5]
@@ -356,6 +370,20 @@ class PetkitBleClient:
         data.battery_voltage_mv = struct.unpack_from(">h", payload, 22)[0]
         data.battery_percent = payload[24]
         data.module_status = payload[25]
+        _LOGGER.debug(
+            "CTW3 state: power=%d suspend=%d mode_raw=%d mode_latched=%d running=%d "
+            "detect=%d electric=%d battery=%d%% filter=%d%% (raw=%s)",
+            data.power_status,
+            data.suspend_status,
+            new_mode,
+            data.mode,
+            data.running_status,
+            data.detect_status,
+            data.electric_status,
+            data.battery_percent,
+            data.filter_percent,
+            payload.hex(),
+        )
 
     @staticmethod
     def _parse_state_generic(data: PetkitFountainData, payload: bytes) -> None:

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -46,10 +46,17 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        """Return the current mode as an option string."""
+        """Return the current mode as an option string.
+
+        If the device reports an unknown mode value (e.g. ``0`` during the
+        CTW3 smart-mode sleep phase) the parser already latches the previous
+        valid value, so this lookup is safe. We still return ``None`` for any
+        unexpected value rather than silently falling back to "normal", which
+        would mislead users (see issue #57).
+        """
         if self.coordinator.data is None:
             return None
-        return _INT_TO_MODE.get(self.coordinator.data.mode, "normal")
+        return _INT_TO_MODE.get(self.coordinator.data.mode)
 
     async def async_select_option(self, option: str) -> None:
         """Send CMD 220 to change mode.

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -132,6 +132,28 @@ class TestStateParsers:
         assert data.battery_percent == 85
         assert data.module_status == 0x01
 
+    def test_parse_state_ctw3_latches_mode_when_zero(self, sample_ctw3_state_payload: bytes) -> None:
+        """If the device reports mode=0 (e.g. smart-mode sleep), keep last mode.
+
+        Regression test for issue #57: the CTW3 firmware can transiently report
+        mode=0 during the smart-mode sleep phase. Treating that literally caused
+        the HA mode select to flip to "Normal" and subsequent power-switch
+        toggles to drop the device out of smart mode.
+        """
+        buf = bytearray(sample_ctw3_state_payload)
+        buf[2] = 0  # device reports unknown mode
+        data = PetkitFountainData(alias=ALIAS_CTW3, mode=2)  # last known: smart
+        PetkitBleClient._parse_state_ctw3(data, bytes(buf))
+        assert data.mode == 2  # latched, not overwritten with 0
+
+    def test_parse_state_ctw3_accepts_valid_mode_change(self, sample_ctw3_state_payload: bytes) -> None:
+        """A valid mode value (1 or 2) from the device must still update."""
+        buf = bytearray(sample_ctw3_state_payload)
+        buf[2] = 1  # device reports normal
+        data = PetkitFountainData(alias=ALIAS_CTW3, mode=2)
+        PetkitBleClient._parse_state_ctw3(data, bytes(buf))
+        assert data.mode == 1
+
     def test_parse_state_generic(self, sample_generic_state_payload: bytes) -> None:
         """Parse a generic state payload and verify fields."""
         data = PetkitFountainData(alias=ALIAS_W5)


### PR DESCRIPTION
Refs #57.

## Summary

On a CTW3 (Eversweet Max 2) the firmware can transiently report `mode = 0` on byte[2] of CMD 210 during the smart-mode sleep phase. Treating that literally caused two regressions visible in the HA UI shortly after a user selected **Smart**:

- The select entity's `_INT_TO_MODE.get(data.mode, 'normal')` silently fell back to `"normal"`, so the mode flipped from Smart to Normal in the UI.
- A subsequent power-switch toggle would read `data.mode == 1` and send CMD 220 `[1, 1, 1]`, dropping the device out of smart mode.

## Changes

- `ble_client._parse_state_ctw3`: only overwrite `data.mode` when the device reports a known mode (`1` or `2`). Unknown values are logged at DEBUG and the previously latched mode is kept.
- Added a structured DEBUG log per CTW3 poll printing `power/suspend/mode_raw/mode_latched/running/detect/electric/battery/filter` plus the raw hex payload, to make analysis of issue #57 easier from user-supplied debug logs.
- `select.PetkitModeSelect.current_option`: tightened the fallback to `None` for unknown modes instead of silently defaulting to `"normal"`.
- Added two regression tests in `test_data_model.py` covering the latch and the still-accept-valid-changes path.
- Version bumped to `1.1.8`.

## Verification

- `uv tool run ruff check` + `ruff format --check` clean.
- All 23 tests in `tests/test_data_model.py` pass, including the two new ones.

## Notes / open questions

This PR does **not** yet change the power switch behaviour. If the device also reports `power_status = 0` during the smart-sleep phase, the power switch may still show Off briefly. We're waiting for the user's debug logs (per issue #57) before redefining `is_on` for CTW3 — too risky to guess without raw CMD 210 captures across a full smart cycle.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>