### PR TITLE
fix(ctw3): self-heal alias when CONF_MODEL was stored as a MAC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist/
 build/
 .pytest_cache/
 .ruff_cache/
+
+Logs/
+uv.lock
+.venv/
+

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -14,6 +14,7 @@ from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
 from .const import (
+    ALIAS_CTW3,
     AUTH_STEP_DELAY,
     BLE_NOTIFY_UUID,
     BLE_WRITE_UUID,
@@ -26,6 +27,7 @@ from .const import (
     CMD_GET_STATE,
     CMD_SET_TIME,
     CTW3_ALIASES,
+    CTW3_STATE_PAYLOAD_MIN_LEN,
     DEFAULT_FLOW_DIVISOR,
     DEFAULT_FLOW_RATE_LPM,
     DEFAULT_POWER_COEFF_W,
@@ -37,6 +39,7 @@ from .const import (
     FRAME_HEADER,
     FRAME_TYPE_SEND,
     GATT_SERIAL_NUMBER_UUID,
+    KNOWN_ALIASES,
     POWER_COEFF_W,
 )
 from .protocol import build_init_payload, build_time_sync_payload
@@ -508,7 +511,21 @@ class PetkitBleClient:
             # CMD 210 — device state
             payload_210 = await self._send_and_wait(CMD_GET_STATE, FRAME_TYPE_SEND, [])
             if payload_210 is not None:
-                if alias in CTW3_ALIASES:
+                # Self-heal: when the stored alias is unknown (e.g. a MAC was
+                # baked into CONF_MODEL because the BLE local name was not
+                # available at config-flow time), infer the real model from
+                # the CMD 210 payload length. Generic devices return ≤18 bytes;
+                # CTW3 devices return ≥26 bytes (typically 30).
+                if data.alias not in KNOWN_ALIASES and len(payload_210) >= CTW3_STATE_PAYLOAD_MIN_LEN:
+                    _LOGGER.warning(
+                        "Inferring CTW3 alias from CMD 210 payload length %d "
+                        "(stored alias %r is not a known model). The coordinator "
+                        "will persist this correction to the config entry.",
+                        len(payload_210),
+                        data.alias,
+                    )
+                    data.alias = ALIAS_CTW3
+                if data.alias in CTW3_ALIASES:
                     self._parse_state_ctw3(data, payload_210)
                 else:
                     self._parse_state_generic(data, payload_210)
@@ -516,7 +533,7 @@ class PetkitBleClient:
             # CMD 211 — device config (settings)
             payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [])
             if payload_211 is not None:
-                if alias in CTW3_ALIASES:
+                if data.alias in CTW3_ALIASES:
                     self._parse_config_ctw3(data, payload_211)
                 else:
                     self._parse_config_generic(data, payload_211)

--- a/custom_components/petkit_ble/config_flow.py
+++ b/custom_components/petkit_ble/config_flow.py
@@ -37,7 +37,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _get_alias_from_name(name: str) -> str:
-    """Derive the device alias from its BLE advertisement name."""
+    """Derive the device alias from its BLE advertisement name.
+
+    Returns one of the known ``ALIAS_*`` constants when the BLE name contains
+    a recognisable model token. Returns an empty string when no model can be
+    determined — for example when the proxy advert delivered no local name
+    and the user only provided the MAC. The runtime then self-heals the alias
+    on the first successful poll based on the CMD 210 payload length.
+    """
     if "CTW3" in name:
         return ALIAS_CTW3
     if "CTW2" in name:
@@ -52,7 +59,7 @@ def _get_alias_from_name(name: str) -> str:
         return ALIAS_W4X
     if "W5" in name:
         return ALIAS_W5
-    return name
+    return ""
 
 
 def _is_petkit_device(name: str) -> bool:

--- a/custom_components/petkit_ble/const.py
+++ b/custom_components/petkit_ble/const.py
@@ -70,6 +70,24 @@ PETKIT_NAME_PREFIXES = (
 # Aliases that use the CTW3 26-byte state format
 CTW3_ALIASES = {ALIAS_CTW3}
 
+# Every known alias. Used to detect entries whose CONF_MODEL was stored as
+# something else (e.g. a MAC address — see issue: alias self-heal) so that
+# the runtime can infer the real model from the BLE response and persist it.
+KNOWN_ALIASES = {
+    ALIAS_CTW3,
+    ALIAS_CTW2,
+    ALIAS_W5C,
+    ALIAS_W5N,
+    ALIAS_W5,
+    ALIAS_W4XUVC,
+    ALIAS_W4X,
+}
+
+# CMD 210 payload length threshold used to identify a CTW3. Generic devices
+# return 12-18 bytes; CTW3 devices return ≥26 bytes (typically 30). 22 bytes
+# is a safe midpoint that distinguishes the two without being brittle.
+CTW3_STATE_PAYLOAD_MIN_LEN = 22
+
 # Poll interval in seconds
 POLL_INTERVAL = 60
 

--- a/custom_components/petkit_ble/const.py
+++ b/custom_components/petkit_ble/const.py
@@ -84,9 +84,10 @@ KNOWN_ALIASES = {
 }
 
 # CMD 210 payload length threshold used to identify a CTW3. Generic devices
-# return 12-18 bytes; CTW3 devices return ≥26 bytes (typically 30). 22 bytes
-# is a safe midpoint that distinguishes the two without being brittle.
-CTW3_STATE_PAYLOAD_MIN_LEN = 22
+# return 12-18 bytes; CTW3 devices require at least 26 bytes for the CTW3
+# state parser to succeed, so only payloads of 26 bytes or more should infer
+# the CTW3 model.
+CTW3_STATE_PAYLOAD_MIN_LEN = 26
 
 # Poll interval in seconds
 POLL_INTERVAL = 60

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from .ble_client import PetkitBleClient, PetkitFountainData
-from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
+from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, KNOWN_ALIASES, POLL_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -201,6 +201,25 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         _LOGGER.debug(
             "Polled %s: power=%s mode=%s firmware=%s", self._name, data.power_status, data.mode, data.firmware
         )
+
+        # Self-heal persistence: if the BLE client inferred a corrected alias
+        # from the CMD 210 payload (e.g. when the original entry stored a MAC
+        # as CONF_MODEL), persist the corrected alias to the config entry so
+        # subsequent polls — and any switch/select writes — use the correct
+        # device model immediately.
+        if data.alias and data.alias != self._alias and data.alias in KNOWN_ALIASES:
+            _LOGGER.warning(
+                "Auto-correcting stored model for %s (%s): %r → %r. Persisting to config entry.",
+                self._name,
+                self._address,
+                self._alias,
+                data.alias,
+            )
+            self._alias = data.alias
+            self.hass.config_entries.async_update_entry(
+                self._config_entry,
+                data={**self._config_entry.data, CONF_MODEL: data.alias},
+            )
 
         # Track drink events: detect_status transitions 0→1
         # No pump check — in smart mode the pump may be off while pet drinks

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/tests/test_alias_detection.py
+++ b/tests/test_alias_detection.py
@@ -85,5 +85,60 @@ class TestStatePayloadLengthDiscriminator:
 
     def test_threshold_at_or_below_ctw3(self) -> None:
         # CTW3 payloads observed in the field are 26-30 bytes; threshold must
-        # not exceed the smallest observed CTW3 payload.
+        # not exceed the smallest observed CTW3 payload, otherwise valid CTW3
+        # frames would be misclassified as generic.
         assert CTW3_STATE_PAYLOAD_MIN_LEN <= 26
+
+    def test_threshold_matches_ctw3_parser_minimum(self) -> None:
+        # The CTW3 parser requires at least 26 bytes; inferring CTW3 from a
+        # shorter payload would persist the alias and then immediately fail to
+        # parse. Keep the discriminator aligned with the parser minimum.
+        assert CTW3_STATE_PAYLOAD_MIN_LEN == 26
+
+
+class TestCtw3SelfHealInference:
+    """Cover the alias self-heal branch in PetkitBleClient.async_poll.
+
+    async_poll itself requires a connected BleakClient, but the self-heal
+    decision is a pure check on (data.alias, len(payload_210)). Exercise the
+    same condition + parser dispatch the live code uses, to lock in the
+    behaviour: an unknown stored alias plus a CTW3-sized payload must (a)
+    select the CTW3 parser and (b) yield the expected CTW3 fields.
+    """
+
+    def test_mac_alias_with_ctw3_payload_uses_ctw3_parser(self, sample_ctw3_state_payload: bytes) -> None:
+        from custom_components.petkit_ble.ble_client import (
+            PetkitBleClient,
+            PetkitFountainData,
+        )
+        from custom_components.petkit_ble.const import CTW3_ALIASES
+
+        data = PetkitFountainData(alias="A4:C1:38:E6:2B:1C")
+
+        # Mirror the live self-heal condition in async_poll.
+        if data.alias not in KNOWN_ALIASES and len(sample_ctw3_state_payload) >= CTW3_STATE_PAYLOAD_MIN_LEN:
+            data.alias = ALIAS_CTW3
+
+        assert data.alias == ALIAS_CTW3
+        assert data.alias in CTW3_ALIASES
+
+        PetkitBleClient._parse_state_ctw3(data, sample_ctw3_state_payload)
+
+        # Spot-check fields that only the CTW3 parser populates correctly.
+        assert data.power_status == 1
+        assert data.suspend_status == 0
+        assert data.mode == 2
+        assert data.electric_status == 2
+        assert data.battery_percent == 85
+
+    def test_short_payload_does_not_trigger_inference(self) -> None:
+        # An 18-byte generic payload must NOT cause CTW3 inference, even
+        # though the stored alias is unknown.
+        from custom_components.petkit_ble.ble_client import PetkitFountainData
+
+        data = PetkitFountainData(alias="A4:C1:38:E6:2B:1C")
+        payload = bytes(18)
+
+        triggered = data.alias not in KNOWN_ALIASES and len(payload) >= CTW3_STATE_PAYLOAD_MIN_LEN
+
+        assert triggered is False

--- a/tests/test_alias_detection.py
+++ b/tests/test_alias_detection.py
@@ -1,0 +1,89 @@
+"""Tests for alias detection and self-heal logic."""
+
+from __future__ import annotations
+
+from custom_components.petkit_ble.config_flow import _get_alias_from_name
+from custom_components.petkit_ble.const import (
+    ALIAS_CTW2,
+    ALIAS_CTW3,
+    ALIAS_W4X,
+    ALIAS_W4XUVC,
+    ALIAS_W5,
+    ALIAS_W5C,
+    ALIAS_W5N,
+    CTW3_STATE_PAYLOAD_MIN_LEN,
+    KNOWN_ALIASES,
+)
+
+
+class TestGetAliasFromName:
+    """Tests for _get_alias_from_name."""
+
+    def test_ctw3_name(self) -> None:
+        assert _get_alias_from_name("Petkit_CTW3_100") == ALIAS_CTW3
+
+    def test_ctw2_name(self) -> None:
+        assert _get_alias_from_name("Petkit_CTW2_42") == ALIAS_CTW2
+
+    def test_w5c_before_w5(self) -> None:
+        # Order matters: W5C must be matched before the generic W5 fallback.
+        assert _get_alias_from_name("Petkit_W5C_01") == ALIAS_W5C
+
+    def test_w5n_before_w5(self) -> None:
+        assert _get_alias_from_name("Petkit_W5N_01") == ALIAS_W5N
+
+    def test_w4xuvc_before_w4x(self) -> None:
+        assert _get_alias_from_name("Petkit_W4XUVC_99") == ALIAS_W4XUVC
+
+    def test_w4x(self) -> None:
+        assert _get_alias_from_name("Petkit_W4X_01") == ALIAS_W4X
+
+    def test_w5_generic(self) -> None:
+        assert _get_alias_from_name("Petkit_W5_01") == ALIAS_W5
+
+    def test_mac_returns_empty(self) -> None:
+        """MAC-as-name must not be echoed as the alias.
+
+        Regression test for the alias-self-heal bug: when the BLE local name
+        was unavailable at config-flow time (common with proxy adverts) the
+        old code returned the raw input — typically the MAC — as the alias,
+        which then poisoned all downstream model-specific behaviour.
+        """
+        assert _get_alias_from_name("A4:C1:38:E6:2B:1C") == ""
+
+    def test_empty_returns_empty(self) -> None:
+        assert _get_alias_from_name("") == ""
+
+    def test_unknown_token_returns_empty(self) -> None:
+        assert _get_alias_from_name("SomeOtherDevice") == ""
+
+
+class TestKnownAliases:
+    """Sanity checks for the KNOWN_ALIASES set."""
+
+    def test_contains_all_aliases(self) -> None:
+        assert ALIAS_CTW3 in KNOWN_ALIASES
+        assert ALIAS_CTW2 in KNOWN_ALIASES
+        assert ALIAS_W5C in KNOWN_ALIASES
+        assert ALIAS_W5N in KNOWN_ALIASES
+        assert ALIAS_W5 in KNOWN_ALIASES
+        assert ALIAS_W4XUVC in KNOWN_ALIASES
+        assert ALIAS_W4X in KNOWN_ALIASES
+
+    def test_does_not_contain_mac_or_empty(self) -> None:
+        assert "A4:C1:38:E6:2B:1C" not in KNOWN_ALIASES
+        assert "" not in KNOWN_ALIASES
+
+
+class TestStatePayloadLengthDiscriminator:
+    """The CTW3 self-heal threshold must distinguish CTW3 from generic."""
+
+    def test_threshold_above_generic(self) -> None:
+        # Generic CMD 210 payloads observed in the field are 12-18 bytes;
+        # threshold must be strictly greater.
+        assert CTW3_STATE_PAYLOAD_MIN_LEN > 18
+
+    def test_threshold_at_or_below_ctw3(self) -> None:
+        # CTW3 payloads observed in the field are 26-30 bytes; threshold must
+        # not exceed the smallest observed CTW3 payload.
+        assert CTW3_STATE_PAYLOAD_MIN_LEN <= 26


### PR DESCRIPTION
## Problem

Closes #59.

User-supplied debug log showed mode-switch in HA doing nothing on a real CTW3. The cause is `CONF_MODEL` containing the **MAC address** instead of `"CTW3"`, which makes the integration:

- send the wrong CMD 220 payload (2-byte generic instead of 3-byte CTW3) → device ignores mode change,
- parse CMD 210/211 with the wrong layout → all sensors wrong.

The MAC ended up there because `config_flow._get_alias_from_name()` echoed the raw input when no model token matched. With proxy adverts that arrive without a local name this is easy to hit.

## Fix

- **`ble_client.py`** – `async_poll` infers `ALIAS_CTW3` from a `>= 22` byte CMD 210 payload when the stored alias is unknown, then uses the correct parser and logs a `WARNING`.
- **`coordinator.py`** – persists the corrected alias to the config entry via `async_update_entry`, so subsequent polls and switch/select writes use the right model immediately.
- **`config_flow.py`** – `_get_alias_from_name` returns `""` instead of echoing the input.
- **`const.py`** – new `KNOWN_ALIASES` set and `CTW3_STATE_PAYLOAD_MIN_LEN = 22`.
- **`manifest.json`** – `1.1.8` → `1.1.9`.
- **`tests/test_alias_detection.py`** – 14 new unit tests.

Existing broken entries auto-correct themselves on the first successful poll. No reconfigure required.

## Tests

- `uv tool run ruff check custom_components/ tests/` ✅
- `uv tool run ruff format --check custom_components/ tests/` ✅
- `uv tool run --from pytest pytest tests/ -v` → 57 passed.