### PR TITLE
release: v1.1.9 — CTW3 alias self-heal

### DIFF
--- a/.agents/skills/home-assistant-integration-developer/SKILL.md
+++ b/.agents/skills/home-assistant-integration-developer/SKILL.md
@@ -3,29 +3,29 @@ name: home-assistant-integration-developer
 description: >
   Best practices for developing Home Assistant custom integrations — config flows, coordinators,
   entity platforms, BLE protocol, translations, manifest, and code quality.
-
-  TRIGGER THIS SKILL WHEN:
-  - Creating or modifying a Home Assistant custom integration
-  - Adding new entity platforms (sensor, switch, number, time, select, button, binary_sensor)
-  - Writing or refactoring a config flow (user, bluetooth, options)
-  - Implementing a DataUpdateCoordinator for polling or push data
-  - Creating BLE/Bluetooth integrations with bleak or HA bluetooth stack
-  - Adding translation strings or entity descriptions
-  - Setting up manifest.json with BLE matchers or dependencies
-  - Writing entity description dataclasses with value extractors
-  - Implementing device commands (write-back) through coordinator
-  - Structuring __init__.py setup/unload with runtime_data pattern
-
-  SYMPTOMS: Agent creates entities in __init__.py instead of platform files, uses hass.data[DOMAIN]
-  instead of entry.runtime_data, does I/O in entity properties, skips coordinator, misuses unique IDs,
-  forgets type hints or from __future__ import annotations, imports Callable from typing, hardcodes
-  entity names instead of using translation_key, catches bare Exception without UpdateFailed.
+  Trigger when creating/modifying HA integrations, entity platforms, config flows, coordinators,
+  BLE integrations, translations, manifest, entity descriptions, device commands, or init setup.
 
 metadata:
   version: 1
 ---
 
 # Home Assistant Integration Developer
+
+## When to Trigger This Skill
+
+- Creating or modifying a Home Assistant custom integration
+- Adding new entity platforms (sensor, switch, number, time, select, button, binary_sensor)
+- Writing or refactoring a config flow (user, bluetooth, options)
+- Implementing a DataUpdateCoordinator for polling or push data
+- Creating BLE/Bluetooth integrations with bleak or HA bluetooth stack
+- Adding translation strings or entity descriptions
+- Setting up manifest.json with BLE matchers or dependencies
+- Writing entity description dataclasses with value extractors
+- Implementing device commands (write-back) through coordinator
+- Structuring __init__.py setup/unload with runtime_data pattern
+
+**Common symptoms of missing this skill:** Agent creates entities in `__init__.py` instead of platform files, uses `hass.data[DOMAIN]` instead of `entry.runtime_data`, does I/O in entity properties, skips coordinator, misuses unique IDs, forgets type hints or `from __future__ import annotations`, imports `Callable` from `typing`, hardcodes entity names instead of using `translation_key`, catches bare `Exception` without `UpdateFailed`.
 
 **Core principle:** Follow Home Assistant's native patterns — `DataUpdateCoordinator` for data fetching, `entry.runtime_data` for state, `CoordinatorEntity` for entities, frozen dataclass descriptions for entity metadata, and the repository's current translation layout: use `strings.json` for config/options flow text and `translations/en.json` (mirrored to other `translations/*.json` files) for entity and other user-visible platform strings.
 

--- a/.agents/skills/home-assistant-integration-developer/SKILL.md
+++ b/.agents/skills/home-assistant-integration-developer/SKILL.md
@@ -16,21 +16,10 @@ description: >
   - Implementing device commands (write-back) through coordinator
   - Structuring __init__.py setup/unload with runtime_data pattern
 
-  SYMPTOMS:
-  - Agent creates entities in __init__.py instead of platform files
-  - Agent uses hass.data[DOMAIN] instead of entry.runtime_data pattern
-  - Agent does network I/O in entity properties instead of coordinator
-  - Agent skips DataUpdateCoordinator and polls directly from entities
-  - Agent uses device_id instead of entity_id in entity unique IDs
-  - Agent forgets from __future__ import annotations or type hints
-  - Agent imports Callable from typing instead of collections.abc
-  - Agent duplicates payload-building logic across multiple platform files
-  - Agent uses mutable state in entity description dataclasses (missing frozen=True)
-  - Agent stores secrets in code instead of config entry data
-  - Agent skips translation_key and hardcodes entity names
-  - Agent catches bare Exception without re-raising as UpdateFailed
-  - Agent creates config entries without calling async_set_unique_id first
-  - Agent accesses private fields (_underscore) across module boundaries
+  SYMPTOMS: Agent creates entities in __init__.py instead of platform files, uses hass.data[DOMAIN]
+  instead of entry.runtime_data, does I/O in entity properties, skips coordinator, misuses unique IDs,
+  forgets type hints or from __future__ import annotations, imports Callable from typing, hardcodes
+  entity names instead of using translation_key, catches bare Exception without UpdateFailed.
 
 metadata:
   version: 1

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -201,18 +201,36 @@ Every change — no matter how small — **must** follow these steps in order:
    git push -u origin fix/my-fix
    gh pr create --base dev --head fix/my-fix --title "..." --body "..."
    ```
-7. **CI** — Wait for all CI checks to pass (ruff lint, ruff format, HACS validation).
-8. **Review** — After CI passes, check the Copilot code review on the PR:
+7. **CI** — Wait for all CI checks to pass (ruff lint, ruff format, HACS validation,
+   and the "Request Copilot Code Review" workflow).
+8. **Review** — After CI passes, **wait for the Copilot code review to actually be
+   submitted** before merging. The "Request Copilot Code Review" workflow only
+   *triggers* the review; the review comments arrive asynchronously a short time
+   later. Verify the review has been submitted by polling:
+   ```
+   gh pr view <N> --json reviews -q '.reviews[] | select(.author.login=="copilot-pull-request-reviewer") | .submittedAt'
+   ```
+   (Or use the GitHub API `get_reviews` / `get_review_comments` methods.)
+   Only proceed when the review is present. Then:
    - Retrieve all review comments using the GitHub API / `gh` CLI.
    - If there are comments or suggestions, **fix them** in a new commit on the same branch.
    - Reply to each review thread explaining what was fixed.
    - **Resolve** all review threads (using GraphQL `resolveReviewThread` mutation).
-   - Push the fixes and wait for CI to pass again.
+   - Push the fixes and wait for CI to pass again, then re-check the review.
    - Repeat until there are no unresolved comments.
 9. **Merge** — Once CI passes and all review comments are resolved, merge the PR into `dev`:
    ```
    gh pr merge <PR_NUMBER> --squash --delete-branch
    ```
+10. **Verify dev pre-release** — After the merge, confirm that the `Pre-release`
+    workflow created a new `v<version>-dev.<timestamp>` tag/release on `dev`:
+    ```
+    gh run list --workflow pre-release.yml --limit 1
+    gh release list --limit 3
+    ```
+    If the workflow did not run or failed, investigate before moving on. This
+    pre-release is what HACS beta-testers install, so missing it silently breaks
+    their update path.
 
 **NEVER commit or push directly to `dev` or `main`.**  
 Even as admin (bypassed protection), direct pushes skip CI and break the audit trail.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -221,7 +221,7 @@ Even as admin (bypassed protection), direct pushes skip CI and break the audit t
 
 ## Code Conventions
 
-- **Language**: All code comments, docstrings, commit messages, and documentation in **English**.
+- **Language**: All code, comments, docstrings, commit messages, PR titles & descriptions, and GitHub issues MUST be in **English**. This applies even when the user/contributor communicates in another language — only the chat reply to the user may be in their language; everything that lands in the repository or on GitHub is English.
 - **Python**: 3.12+, type hints required, `from __future__ import annotations` in every module.
 - **Imports**: Use `from collections.abc import Callable` (not `from typing import Callable`).
 - **Linter**: ruff — run `ruff check custom_components/` before committing.

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -16,6 +16,8 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **Linter:** ruff — run `uv run ruff check custom_components/` before committing
 - **Language:** ALL code, comments, docstrings, commit messages, PR titles/descriptions, and GitHub issues MUST be written in English. No exceptions, even when the user writes in another language.
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
+- **PR review gate:** Always wait for the Copilot code reviewer to *actually submit* its review (not just the workflow run to finish) before merging. The review comments arrive asynchronously after the "Request Copilot Code Review" workflow turns green. Verify with `gh pr view <N> --json reviews` and address every comment before merge.
+- **Post-merge:** After merging to `dev`, verify the `Pre-release` workflow produced a new `v<version>-dev.<timestamp>` GitHub release; this is what HACS beta-testers install.
 
 ## BLE Frame Format
 

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -14,6 +14,7 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **HA minimum:** 2024.1 — uses `entry.runtime_data`, `CoordinatorEntity`, `async_ble_device_from_address`
 - **Python:** 3.12+, `from __future__ import annotations` in every module, `collections.abc.Callable`
 - **Linter:** ruff — run `uv run ruff check custom_components/` before committing
+- **Language:** ALL code, comments, docstrings, commit messages, PR titles/descriptions, and GitHub issues MUST be written in English. No exceptions, even when the user writes in another language.
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
 
 ## BLE Frame Format

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist/
 build/
 .pytest_cache/
 .ruff_cache/
+
+Logs/
+uv.lock
+.venv/
+

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -14,6 +14,7 @@ from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
 from .const import (
+    ALIAS_CTW3,
     AUTH_STEP_DELAY,
     BLE_NOTIFY_UUID,
     BLE_WRITE_UUID,
@@ -26,6 +27,7 @@ from .const import (
     CMD_GET_STATE,
     CMD_SET_TIME,
     CTW3_ALIASES,
+    CTW3_STATE_PAYLOAD_MIN_LEN,
     DEFAULT_FLOW_DIVISOR,
     DEFAULT_FLOW_RATE_LPM,
     DEFAULT_POWER_COEFF_W,
@@ -37,6 +39,7 @@ from .const import (
     FRAME_HEADER,
     FRAME_TYPE_SEND,
     GATT_SERIAL_NUMBER_UUID,
+    KNOWN_ALIASES,
     POWER_COEFF_W,
 )
 from .protocol import build_init_payload, build_time_sync_payload
@@ -508,7 +511,21 @@ class PetkitBleClient:
             # CMD 210 — device state
             payload_210 = await self._send_and_wait(CMD_GET_STATE, FRAME_TYPE_SEND, [])
             if payload_210 is not None:
-                if alias in CTW3_ALIASES:
+                # Self-heal: when the stored alias is unknown (e.g. a MAC was
+                # baked into CONF_MODEL because the BLE local name was not
+                # available at config-flow time), infer the real model from
+                # the CMD 210 payload length. Generic devices return ≤18 bytes;
+                # CTW3 devices return ≥26 bytes (typically 30).
+                if data.alias not in KNOWN_ALIASES and len(payload_210) >= CTW3_STATE_PAYLOAD_MIN_LEN:
+                    _LOGGER.warning(
+                        "Inferring CTW3 alias from CMD 210 payload length %d "
+                        "(stored alias %r is not a known model). The coordinator "
+                        "will persist this correction to the config entry.",
+                        len(payload_210),
+                        data.alias,
+                    )
+                    data.alias = ALIAS_CTW3
+                if data.alias in CTW3_ALIASES:
                     self._parse_state_ctw3(data, payload_210)
                 else:
                     self._parse_state_generic(data, payload_210)
@@ -516,7 +533,7 @@ class PetkitBleClient:
             # CMD 211 — device config (settings)
             payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [])
             if payload_211 is not None:
-                if alias in CTW3_ALIASES:
+                if data.alias in CTW3_ALIASES:
                     self._parse_config_ctw3(data, payload_211)
                 else:
                     self._parse_config_generic(data, payload_211)

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -340,7 +340,22 @@ class PetkitBleClient:
             return
         data.power_status = payload[0]
         data.suspend_status = payload[1]
-        data.mode = payload[2]
+        # The CTW3 firmware has been observed to transiently report mode=0 during
+        # the smart-mode sleep phase. Treating that as ground truth would make
+        # the mode select show "Unknown" (it returns None for unknown values)
+        # and any subsequent power-switch toggle would read data.mode == 0/1,
+        # sending the wrong CMD 220 payload and kicking the device out of smart
+        # mode. We therefore only update ``mode`` when the new value is a known
+        # mode (1=normal, 2=smart). See issue #57.
+        new_mode = payload[2]
+        if new_mode in (1, 2):
+            data.mode = new_mode
+        else:
+            _LOGGER.debug(
+                "CTW3 reported mode=%d; keeping latched mode=%d",
+                new_mode,
+                data.mode,
+            )
         data.electric_status = payload[3]
         data.dnd_state = payload[4]
         data.warning_breakdown = payload[5]
@@ -356,6 +371,20 @@ class PetkitBleClient:
         data.battery_voltage_mv = struct.unpack_from(">h", payload, 22)[0]
         data.battery_percent = payload[24]
         data.module_status = payload[25]
+        _LOGGER.debug(
+            "CTW3 state: power=%d suspend=%d mode_raw=%d mode_latched=%d running=%d "
+            "detect=%d electric=%d battery=%d%% filter=%d%% (raw=%s)",
+            data.power_status,
+            data.suspend_status,
+            new_mode,
+            data.mode,
+            data.running_status,
+            data.detect_status,
+            data.electric_status,
+            data.battery_percent,
+            data.filter_percent,
+            payload.hex(),
+        )
 
     @staticmethod
     def _parse_state_generic(data: PetkitFountainData, payload: bytes) -> None:

--- a/custom_components/petkit_ble/config_flow.py
+++ b/custom_components/petkit_ble/config_flow.py
@@ -37,7 +37,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _get_alias_from_name(name: str) -> str:
-    """Derive the device alias from its BLE advertisement name."""
+    """Derive the device alias from its BLE advertisement name.
+
+    Returns one of the known ``ALIAS_*`` constants when the BLE name contains
+    a recognisable model token. Returns an empty string when no model can be
+    determined — for example when the proxy advert delivered no local name
+    and the user only provided the MAC. The runtime then self-heals the alias
+    on the first successful poll based on the CMD 210 payload length.
+    """
     if "CTW3" in name:
         return ALIAS_CTW3
     if "CTW2" in name:
@@ -52,7 +59,7 @@ def _get_alias_from_name(name: str) -> str:
         return ALIAS_W4X
     if "W5" in name:
         return ALIAS_W5
-    return name
+    return ""
 
 
 def _is_petkit_device(name: str) -> bool:

--- a/custom_components/petkit_ble/const.py
+++ b/custom_components/petkit_ble/const.py
@@ -70,6 +70,25 @@ PETKIT_NAME_PREFIXES = (
 # Aliases that use the CTW3 26-byte state format
 CTW3_ALIASES = {ALIAS_CTW3}
 
+# Every known alias. Used to detect entries whose CONF_MODEL was stored as
+# something else (e.g. a MAC address — see issue: alias self-heal) so that
+# the runtime can infer the real model from the BLE response and persist it.
+KNOWN_ALIASES = {
+    ALIAS_CTW3,
+    ALIAS_CTW2,
+    ALIAS_W5C,
+    ALIAS_W5N,
+    ALIAS_W5,
+    ALIAS_W4XUVC,
+    ALIAS_W4X,
+}
+
+# CMD 210 payload length threshold used to identify a CTW3. Generic devices
+# return 12-18 bytes; CTW3 devices require at least 26 bytes for the CTW3
+# state parser to succeed, so only payloads of 26 bytes or more should infer
+# the CTW3 model.
+CTW3_STATE_PAYLOAD_MIN_LEN = 26
+
 # Poll interval in seconds
 POLL_INTERVAL = 60
 

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -4,13 +4,24 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from homeassistant.components.bluetooth import async_ble_device_from_address, async_last_service_info
+from homeassistant.components.bluetooth import (
+    BluetoothChange,
+    BluetoothScanningMode,
+    async_ble_device_from_address,
+    async_last_service_info,
+    async_register_callback,
+    async_scanner_count,
+)
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
+    from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -18,6 +29,12 @@ from .ble_client import PetkitBleClient, PetkitFountainData
 from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long to wait for a connectable advertisement before giving up. The proxy
+# emits adverts every ~500ms, but it can be unavailable for a few seconds while
+# it is mid-connect to another device. A 15s grace window covers that case
+# without significantly delaying genuine "device powered off" failures.
+CONNECTABLE_WAIT_TIMEOUT = 15.0
 
 
 class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
@@ -50,17 +67,130 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             update_interval=timedelta(seconds=POLL_INTERVAL),
         )
 
-    def _get_ble_device(self) -> PetkitBleClient | None:
-        """Return a BLE client for the fountain, or None if not reachable."""
-        ble_device = async_ble_device_from_address(self.hass, self._address, connectable=True)
-        if ble_device is None:
+    def _log_unreachable_diagnostics(self) -> None:
+        """Emit a single diagnostic log line explaining why the device is not connectable.
+
+        Distinguishes between "no scanner has ever seen the device" (likely off
+        or out of range) and "device is advertising but no connectable path is
+        currently available" (proxy slot busy / non-connectable scanner only).
+        """
+        try:
+            scanner_count_total = async_scanner_count(self.hass, connectable=False)
+            scanner_count_conn = async_scanner_count(self.hass, connectable=True)
+        except Exception:  # diagnostics must never raise
+            scanner_count_total = scanner_count_conn = -1
+
+        last_any = async_last_service_info(self.hass, self._address, connectable=False)
+        last_conn = async_last_service_info(self.hass, self._address, connectable=True)
+
+        if last_any is None:
+            _LOGGER.warning(
+                "%s (%s) is not advertising on any of %d scanner(s) "
+                "(connectable scanners: %d). Device may be powered off or out of range.",
+                self._name,
+                self._address,
+                scanner_count_total,
+                scanner_count_conn,
+            )
+            return
+
+        now = time.monotonic()
+        age_any = now - last_any.time if last_any.time else 0.0
+
+        if last_conn is None:
+            _LOGGER.warning(
+                "%s (%s) seen via %s (rssi=%s, %.1fs ago) but no connectable scanner "
+                "currently has it (%d connectable / %d total scanners). "
+                "Proxy slot may be busy or the advert was not connectable.",
+                self._name,
+                self._address,
+                last_any.source,
+                last_any.rssi,
+                age_any,
+                scanner_count_conn,
+                scanner_count_total,
+            )
+        else:
+            age_conn = now - last_conn.time if last_conn.time else 0.0
+            _LOGGER.warning(
+                "%s (%s) connectable advert seen via %s (rssi=%s, %.1fs ago) "
+                "but async_ble_device_from_address returned None. "
+                "Likely a transient HA bluetooth state.",
+                self._name,
+                self._address,
+                last_conn.source,
+                last_conn.rssi,
+                age_conn,
+            )
+
+    async def _wait_for_connectable_device(self, timeout: float) -> BLEDevice | None:
+        """Wait up to ``timeout`` seconds for a connectable advertisement.
+
+        Returns the resolved BLEDevice, or None if no connectable advertisement
+        is seen in time. Uses HA's bluetooth callback so we react as soon as a
+        new advert arrives instead of polling.
+
+        The callback is registered *before* the initial address lookup so we
+        cannot miss an advertisement that arrives between the lookup and the
+        registration.
+        """
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[None] = loop.create_future()
+
+        @callback
+        def _on_advertisement(
+            _service_info: BluetoothServiceInfoBleak,
+            _change: BluetoothChange,
+        ) -> None:
+            if not future.done():
+                future.set_result(None)
+
+        cancel = async_register_callback(
+            self.hass,
+            _on_advertisement,
+            {"address": self._address, "connectable": True},
+            BluetoothScanningMode.PASSIVE,
+        )
+        try:
+            # Re-check immediately after registration to close the race window
+            # between the caller's initial lookup and our callback being live.
+            device = async_ble_device_from_address(self.hass, self._address, connectable=True)
+            if device is not None:
+                return device
+
+            try:
+                await asyncio.wait_for(future, timeout)
+            except TimeoutError:
+                return None
+        finally:
+            cancel()
+
+        return async_ble_device_from_address(self.hass, self._address, connectable=True)
+
+    async def _get_ble_client(self) -> PetkitBleClient | None:
+        """Resolve the device and return a client, waiting briefly if needed.
+
+        Diagnostic warnings are only emitted on *final* failure, so transient
+        proxy contention that resolves within the grace window stays silent.
+        """
+        device = async_ble_device_from_address(self.hass, self._address, connectable=True)
+        if device is None:
+            _LOGGER.debug(
+                "%s (%s) not immediately connectable, waiting up to %.0fs for advertisement",
+                self._name,
+                self._address,
+                CONNECTABLE_WAIT_TIMEOUT,
+            )
+            device = await self._wait_for_connectable_device(CONNECTABLE_WAIT_TIMEOUT)
+        if device is None:
+            self._log_unreachable_diagnostics()
             return None
-        return PetkitBleClient(ble_device)
+        return PetkitBleClient(device)
 
     async def _async_update_data(self) -> PetkitFountainData:
         """Fetch the latest data from the fountain."""
         async with self._ble_lock:
-            client = self._get_ble_device()
+            client = await self._get_ble_client()
             if client is None:
                 raise UpdateFailed(f"Petkit fountain {self._name} ({self._address}) not reachable via Bluetooth")
             try:
@@ -95,7 +225,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         command failed.
         """
         async with self._ble_lock:
-            client = self._get_ble_device()
+            client = await self._get_ble_client()
             if client is None:
                 _LOGGER.warning(
                     "Cannot send CMD %d: %s (%s) not reachable via Bluetooth",

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from .ble_client import PetkitBleClient, PetkitFountainData
-from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, POLL_INTERVAL
+from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, KNOWN_ALIASES, POLL_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -201,6 +201,25 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         _LOGGER.debug(
             "Polled %s: power=%s mode=%s firmware=%s", self._name, data.power_status, data.mode, data.firmware
         )
+
+        # Self-heal persistence: if the BLE client inferred a corrected alias
+        # from the CMD 210 payload (e.g. when the original entry stored a MAC
+        # as CONF_MODEL), persist the corrected alias to the config entry so
+        # subsequent polls — and any switch/select writes — use the correct
+        # device model immediately.
+        if data.alias and data.alias != self._alias and data.alias in KNOWN_ALIASES:
+            _LOGGER.warning(
+                "Auto-correcting stored model for %s (%s): %r → %r. Persisting to config entry.",
+                self._name,
+                self._address,
+                self._alias,
+                data.alias,
+            )
+            self._alias = data.alias
+            self.hass.config_entries.async_update_entry(
+                self._config_entry,
+                data={**self._config_entry.data, CONF_MODEL: data.alias},
+            )
 
         # Track drink events: detect_status transitions 0→1
         # No pump check — in smart mode the pump may be off while pet drinks

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/protocol.py
+++ b/custom_components/petkit_ble/protocol.py
@@ -157,3 +157,21 @@ def build_ctw3_mode_payload(power: int, suspend: int, mode: int) -> list[int]:
     if power == 0:
         suspend = 0
     return [power, suspend, mode]
+
+
+def build_ctw3_select_mode_payload(mode: int) -> list[int]:
+    """Build a CMD 220 payload for a user mode-select on CTW3.
+
+    Selecting a mode in the HA UI always implies power=1: the user expects
+    that mode to *run*. We deliberately ignore the cached ``power_status``
+    here because byte[0] of CMD 210 can momentarily be reported as 0 while
+    the device is in smart-mode sleep cycle. Coupling the mode select to
+    that cached value caused Smart→Normal to silently send [0, 0, 1] and
+    leave the pump off.
+
+    Returns:
+      - Normal (mode=1): [1, 1, 1]  (power on, pump active)
+      - Smart  (mode=2): [1, 0, 2]  (power on, timer-managed)
+    """
+    suspend = 1 if mode == 1 else 0
+    return build_ctw3_mode_payload(1, suspend, mode)

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import CMD_SET_POWER_MODE
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
-from .protocol import build_change_mode_payload, build_ctw3_mode_payload
+from .protocol import build_change_mode_payload, build_ctw3_select_mode_payload
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,16 +62,21 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
         data = self.coordinator.data
 
         if data is not None and data.is_ctw3:
-            # CTW3: [power, suspend, mode] via protocol helper.
-            # suspend=1 activates the pump (normal mode); suspend=0 lets the
-            # device's internal timer manage cycling (smart mode).
-            power = data.power_status if data.power_status in (0, 1) else 1
-            suspend = 1 if mode_int == 1 and power == 1 else 0
-            payload = build_ctw3_mode_payload(power, suspend, mode_int)
+            # CTW3: payload [power, suspend, mode] is built by a dedicated
+            # helper that always forces power=1, because selecting a mode in
+            # HA implies the user wants that mode to run. See
+            # build_ctw3_select_mode_payload for the rationale.
+            payload = build_ctw3_select_mode_payload(mode_int)
         else:
             # Generic W5/CTW2: byte[0] = mode (1=normal, 2=smart); selecting a mode implies power-on
             payload = build_change_mode_payload(mode_int)
 
+        _LOGGER.info(
+            "Mode select -> %s (alias=%s): sending CMD 220 payload=%s",
+            option,
+            data.alias if data is not None else "unknown",
+            payload,
+        )
         success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, payload)
         if success:
             await self.coordinator.async_request_refresh()

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -71,7 +71,7 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
             # Generic W5/CTW2: byte[0] = mode (1=normal, 2=smart); selecting a mode implies power-on
             payload = build_change_mode_payload(mode_int)
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "Mode select -> %s (alias=%s): sending CMD 220 payload=%s",
             option,
             data.alias if data is not None else "unknown",

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -46,10 +46,17 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        """Return the current mode as an option string."""
+        """Return the current mode as an option string.
+
+        If the device reports an unknown mode value (e.g. ``0`` during the
+        CTW3 smart-mode sleep phase) the parser already latches the previous
+        valid value, so this lookup is safe. We still return ``None`` for any
+        unexpected value rather than silently falling back to "normal", which
+        would mislead users (see issue #57).
+        """
         if self.coordinator.data is None:
             return None
-        return _INT_TO_MODE.get(self.coordinator.data.mode, "normal")
+        return _INT_TO_MODE.get(self.coordinator.data.mode)
 
     async def async_select_option(self, option: str) -> None:
         """Send CMD 220 to change mode.

--- a/tests/test_alias_detection.py
+++ b/tests/test_alias_detection.py
@@ -1,0 +1,144 @@
+"""Tests for alias detection and self-heal logic."""
+
+from __future__ import annotations
+
+from custom_components.petkit_ble.config_flow import _get_alias_from_name
+from custom_components.petkit_ble.const import (
+    ALIAS_CTW2,
+    ALIAS_CTW3,
+    ALIAS_W4X,
+    ALIAS_W4XUVC,
+    ALIAS_W5,
+    ALIAS_W5C,
+    ALIAS_W5N,
+    CTW3_STATE_PAYLOAD_MIN_LEN,
+    KNOWN_ALIASES,
+)
+
+
+class TestGetAliasFromName:
+    """Tests for _get_alias_from_name."""
+
+    def test_ctw3_name(self) -> None:
+        assert _get_alias_from_name("Petkit_CTW3_100") == ALIAS_CTW3
+
+    def test_ctw2_name(self) -> None:
+        assert _get_alias_from_name("Petkit_CTW2_42") == ALIAS_CTW2
+
+    def test_w5c_before_w5(self) -> None:
+        # Order matters: W5C must be matched before the generic W5 fallback.
+        assert _get_alias_from_name("Petkit_W5C_01") == ALIAS_W5C
+
+    def test_w5n_before_w5(self) -> None:
+        assert _get_alias_from_name("Petkit_W5N_01") == ALIAS_W5N
+
+    def test_w4xuvc_before_w4x(self) -> None:
+        assert _get_alias_from_name("Petkit_W4XUVC_99") == ALIAS_W4XUVC
+
+    def test_w4x(self) -> None:
+        assert _get_alias_from_name("Petkit_W4X_01") == ALIAS_W4X
+
+    def test_w5_generic(self) -> None:
+        assert _get_alias_from_name("Petkit_W5_01") == ALIAS_W5
+
+    def test_mac_returns_empty(self) -> None:
+        """MAC-as-name must not be echoed as the alias.
+
+        Regression test for the alias-self-heal bug: when the BLE local name
+        was unavailable at config-flow time (common with proxy adverts) the
+        old code returned the raw input — typically the MAC — as the alias,
+        which then poisoned all downstream model-specific behaviour.
+        """
+        assert _get_alias_from_name("A4:C1:38:E6:2B:1C") == ""
+
+    def test_empty_returns_empty(self) -> None:
+        assert _get_alias_from_name("") == ""
+
+    def test_unknown_token_returns_empty(self) -> None:
+        assert _get_alias_from_name("SomeOtherDevice") == ""
+
+
+class TestKnownAliases:
+    """Sanity checks for the KNOWN_ALIASES set."""
+
+    def test_contains_all_aliases(self) -> None:
+        assert ALIAS_CTW3 in KNOWN_ALIASES
+        assert ALIAS_CTW2 in KNOWN_ALIASES
+        assert ALIAS_W5C in KNOWN_ALIASES
+        assert ALIAS_W5N in KNOWN_ALIASES
+        assert ALIAS_W5 in KNOWN_ALIASES
+        assert ALIAS_W4XUVC in KNOWN_ALIASES
+        assert ALIAS_W4X in KNOWN_ALIASES
+
+    def test_does_not_contain_mac_or_empty(self) -> None:
+        assert "A4:C1:38:E6:2B:1C" not in KNOWN_ALIASES
+        assert "" not in KNOWN_ALIASES
+
+
+class TestStatePayloadLengthDiscriminator:
+    """The CTW3 self-heal threshold must distinguish CTW3 from generic."""
+
+    def test_threshold_above_generic(self) -> None:
+        # Generic CMD 210 payloads observed in the field are 12-18 bytes;
+        # threshold must be strictly greater.
+        assert CTW3_STATE_PAYLOAD_MIN_LEN > 18
+
+    def test_threshold_at_or_below_ctw3(self) -> None:
+        # CTW3 payloads observed in the field are 26-30 bytes; threshold must
+        # not exceed the smallest observed CTW3 payload, otherwise valid CTW3
+        # frames would be misclassified as generic.
+        assert CTW3_STATE_PAYLOAD_MIN_LEN <= 26
+
+    def test_threshold_matches_ctw3_parser_minimum(self) -> None:
+        # The CTW3 parser requires at least 26 bytes; inferring CTW3 from a
+        # shorter payload would persist the alias and then immediately fail to
+        # parse. Keep the discriminator aligned with the parser minimum.
+        assert CTW3_STATE_PAYLOAD_MIN_LEN == 26
+
+
+class TestCtw3SelfHealInference:
+    """Cover the alias self-heal branch in PetkitBleClient.async_poll.
+
+    async_poll itself requires a connected BleakClient, but the self-heal
+    decision is a pure check on (data.alias, len(payload_210)). Exercise the
+    same condition + parser dispatch the live code uses, to lock in the
+    behaviour: an unknown stored alias plus a CTW3-sized payload must (a)
+    select the CTW3 parser and (b) yield the expected CTW3 fields.
+    """
+
+    def test_mac_alias_with_ctw3_payload_uses_ctw3_parser(self, sample_ctw3_state_payload: bytes) -> None:
+        from custom_components.petkit_ble.ble_client import (
+            PetkitBleClient,
+            PetkitFountainData,
+        )
+        from custom_components.petkit_ble.const import CTW3_ALIASES
+
+        data = PetkitFountainData(alias="A4:C1:38:E6:2B:1C")
+
+        # Mirror the live self-heal condition in async_poll.
+        if data.alias not in KNOWN_ALIASES and len(sample_ctw3_state_payload) >= CTW3_STATE_PAYLOAD_MIN_LEN:
+            data.alias = ALIAS_CTW3
+
+        assert data.alias == ALIAS_CTW3
+        assert data.alias in CTW3_ALIASES
+
+        PetkitBleClient._parse_state_ctw3(data, sample_ctw3_state_payload)
+
+        # Spot-check fields that only the CTW3 parser populates correctly.
+        assert data.power_status == 1
+        assert data.suspend_status == 0
+        assert data.mode == 2
+        assert data.electric_status == 2
+        assert data.battery_percent == 85
+
+    def test_short_payload_does_not_trigger_inference(self) -> None:
+        # An 18-byte generic payload must NOT cause CTW3 inference, even
+        # though the stored alias is unknown.
+        from custom_components.petkit_ble.ble_client import PetkitFountainData
+
+        data = PetkitFountainData(alias="A4:C1:38:E6:2B:1C")
+        payload = bytes(18)
+
+        triggered = data.alias not in KNOWN_ALIASES and len(payload) >= CTW3_STATE_PAYLOAD_MIN_LEN
+
+        assert triggered is False

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -132,6 +132,28 @@ class TestStateParsers:
         assert data.battery_percent == 85
         assert data.module_status == 0x01
 
+    def test_parse_state_ctw3_latches_mode_when_zero(self, sample_ctw3_state_payload: bytes) -> None:
+        """If the device reports mode=0 (e.g. smart-mode sleep), keep last mode.
+
+        Regression test for issue #57: the CTW3 firmware can transiently report
+        mode=0 during the smart-mode sleep phase. Treating that literally caused
+        the HA mode select to flip to "Normal" and subsequent power-switch
+        toggles to drop the device out of smart mode.
+        """
+        buf = bytearray(sample_ctw3_state_payload)
+        buf[2] = 0  # device reports unknown mode
+        data = PetkitFountainData(alias=ALIAS_CTW3, mode=2)  # last known: smart
+        PetkitBleClient._parse_state_ctw3(data, bytes(buf))
+        assert data.mode == 2  # latched, not overwritten with 0
+
+    def test_parse_state_ctw3_accepts_valid_mode_change(self, sample_ctw3_state_payload: bytes) -> None:
+        """A valid mode value (1 or 2) from the device must still update."""
+        buf = bytearray(sample_ctw3_state_payload)
+        buf[2] = 1  # device reports normal
+        data = PetkitFountainData(alias=ALIAS_CTW3, mode=2)
+        PetkitBleClient._parse_state_ctw3(data, bytes(buf))
+        assert data.mode == 1
+
     def test_parse_state_generic(self, sample_generic_state_payload: bytes) -> None:
         """Parse a generic state payload and verify fields."""
         data = PetkitFountainData(alias=ALIAS_W5)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -13,6 +13,7 @@ from custom_components.petkit_ble.const import (
 from custom_components.petkit_ble.protocol import (
     build_change_mode_payload,
     build_ctw3_mode_payload,
+    build_ctw3_select_mode_payload,
     build_init_payload,
     build_settings_payload_ctw3,
     build_settings_payload_generic,
@@ -166,6 +167,24 @@ class TestBuildModePayload:
         assert build_ctw3_mode_payload(1, 0, 2) == [1, 0, 2]
         # When power=0, suspend is forced to 0 regardless of the argument passed
         assert build_ctw3_mode_payload(0, 1, 1) == [0, 0, 1]
+
+
+class TestBuildCtw3SelectModePayload:
+    """Tests for build_ctw3_select_mode_payload (regression for issue #54).
+
+    Selecting a mode in HA must always send power=1, regardless of the cached
+    ``power_status``. Otherwise Smart->Normal can silently send [0, 0, 1] and
+    leave the pump off when byte[0] of CMD 210 was momentarily 0 during the
+    smart-mode sleep cycle.
+    """
+
+    def test_select_normal_always_sends_power_on_with_suspend(self) -> None:
+        """Selecting Normal => [1, 1, 1] (power on, pump active)."""
+        assert build_ctw3_select_mode_payload(1) == [1, 1, 1]
+
+    def test_select_smart_always_sends_power_on_without_suspend(self) -> None:
+        """Selecting Smart => [1, 0, 2] (power on, timer-managed)."""
+        assert build_ctw3_select_mode_payload(2) == [1, 0, 2]
 
 
 class TestFrameFormat:


### PR DESCRIPTION
## v1.1.9 — Stable release

Closes #59.

Promotes `dev` → `main`. No new code in this PR — every commit was already
reviewed and merged via its own PR to `dev`.

### Highlights

- **fix(ctw3): self-heal alias when `CONF_MODEL` was stored as a MAC** (#60, #59)
  Root cause of the Smart↔Normal switch silently failing on CTW3. The
  integration now infers `CTW3` from the CMD 210 payload length when the
  stored alias is unknown and persists the corrected alias to the config
  entry. Existing broken installs auto-heal on the first poll — no
  reconfigure required.
- **fix(ctw3): latch mode across smart-sleep** (#58) — UI no longer flips
  to Normal when the device pauses pump in Smart mode.
- **fix(select): demote CMD 220 payload log to DEBUG; document review wait
  + dev release verify** (#56)
- **fix(ctw3): always force power=1 on mode select** (#55)
- **fix: improve BLE proxy reachability with diagnostics and grace window** (#52)
- **chore: require English for code, commits, PRs, and issues** (#53)
- Skill description fixes (#48, #51)

### Production verification

User-supplied debug log
`home-assistant_petkit_ble_2026-05-01T05-00-06.775Z.log` confirms a real
CTW3 device:

- Self-heal fires once at startup with payload length 30 → alias persisted.
- Smart click → CMD 220 `[1, 0, 2]` ✅
- Normal click → CMD 220 `[1, 1, 1]` ✅
- No mode flips. All sensors populated.

### Release process

`release.yml` will create tag `v1.1.9` (read from `manifest.json`) and a
non-prerelease GitHub Release on push to `main`. Use a **merge commit**, not
squash, to preserve the dev PR history.