### PR TITLE
chore(docs): require minor version bump on dev->main release PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,16 +250,17 @@ versions are the right granularity for "shipped to all HACS users".
 - While working on `dev`, patch increments (`1.1.x`) are used for each
   fix/feature PR — that's what the `Pre-release` workflow tags as
   `v1.1.x-dev.<timestamp>` for HACS beta testers.
-- When opening the release PR `dev` → `main`, **bump
-  `custom_components/petkit_ble/manifest.json` to the next minor**:
+- **Before** opening the release PR, land a normal `chore/release-…` PR
+  into `dev` that bumps `custom_components/petkit_ble/manifest.json` to
+  the next minor (patch reset to `0`):
   - `1.1.8` → `1.2.0`
   - `1.2.2` → `1.3.0`
   - `1.5.7` → `1.6.0`
-  Reset patch to `0`.
-- Do this in a dedicated commit on `dev` *before* opening the release PR
-  (or as the first commit of a short-lived `release/vX.Y.0` branch). The
-  release workflow reads the version from `manifest.json`, so the bump
-  must be on `dev` HEAD when the release PR is merged.
+
+  The release workflow reads the version from `manifest.json`, so the
+  bump must already be on `dev` HEAD when the release PR is merged into
+  `main`. Use the existing `chore/*` branch prefix — no new branch
+  category is introduced for this step.
 - **Major version bumps** (`1.x.y` → `2.0.0`) are reserved for breaking
   changes to the integration's user-facing config or entity model and
   must be discussed with the user first.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -237,6 +237,50 @@ Even as admin (bypassed protection), direct pushes skip CI and break the audit t
 
 ---
 
+## Releasing — promoting `dev` → `main`
+
+When promoting `dev` to `main` for a stable release, the `manifest.json`
+version **must be bumped to a new minor**, never just published with the
+trailing dev patch number. Each merge of `dev` into `main` represents a
+batch of user-visible changes accumulated during the dev cycle, and minor
+versions are the right granularity for "shipped to all HACS users".
+
+### Versioning rule (semver, minor-on-release)
+
+- While working on `dev`, patch increments (`1.1.x`) are used for each
+  fix/feature PR — that's what the `Pre-release` workflow tags as
+  `v1.1.x-dev.<timestamp>` for HACS beta testers.
+- When opening the release PR `dev` → `main`, **bump
+  `custom_components/petkit_ble/manifest.json` to the next minor**:
+  - `1.1.8` → `1.2.0`
+  - `1.2.2` → `1.3.0`
+  - `1.5.7` → `1.6.0`
+  Reset patch to `0`.
+- Do this in a dedicated commit on `dev` *before* opening the release PR
+  (or as the first commit of a short-lived `release/vX.Y.0` branch). The
+  release workflow reads the version from `manifest.json`, so the bump
+  must be on `dev` HEAD when the release PR is merged.
+- **Major version bumps** (`1.x.y` → `2.0.0`) are reserved for breaking
+  changes to the integration's user-facing config or entity model and
+  must be discussed with the user first.
+
+### Release PR checklist
+
+1. On `dev`, bump `manifest.json` `version` to the next minor.
+2. Commit: `chore(release): bump version to vX.Y.0` and push (via a normal
+   PR to `dev` — never direct push).
+3. Open release PR: `gh pr create --base main --head dev --title
+   "release: vX.Y.0 — <summary>"`.
+4. Wait for CI green and the Copilot review **submitted** (same gate as
+   feature PRs).
+5. Resolve any review comments.
+6. **Merge with a merge commit** (`gh pr merge <N> --merge`), **never
+   squash** — the dev PR history must be preserved on `main`.
+7. Verify `release.yml` published a non-prerelease `vX.Y.0` GitHub
+   Release.
+
+---
+
 ## Code Conventions
 
 - **Language**: All code, comments, docstrings, commit messages, PR titles & descriptions, and GitHub issues MUST be in **English**. This applies even when the user/contributor communicates in another language — only the chat reply to the user may be in their language; everything that lands in the repository or on GitHub is English.

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -18,7 +18,11 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
 - **PR review gate:** Always wait for the Copilot code reviewer to *actually submit* its review (not just the workflow run to finish) before merging. The review comments arrive asynchronously after the "Request Copilot Code Review" workflow turns green. Verify with `gh pr view <N> --json reviews` and address every comment before merge.
 - **Post-merge:** After merging to `dev`, verify the `Pre-release` workflow produced a new `v<version>-dev.<timestamp>` GitHub release; this is what HACS beta-testers install.
-- **Releasing dev → main:** Each `dev` → `main` promotion is a stable release and **must** bump `manifest.json` to the next **minor** (e.g. `1.1.8` → `1.2.0`, `1.2.2` → `1.3.0`, `1.5.7` → `1.6.0`; reset patch to `0`). The version bump goes onto `dev` first (via a normal PR), then open the release PR `dev` → `main` titled `release: vX.Y.0 — …`, wait for CI + Copilot review submitted, resolve comments, and **merge with a merge commit (`--merge`, NOT squash)** so the dev PR history is preserved. `release.yml` then publishes the stable `vX.Y.0` GitHub Release. Major bumps (`1.x.y` → `2.0.0`) are reserved for breaking changes and need explicit user approval.
+- **Releasing dev → main:** Each `dev` → `main` promotion is a stable release. See `.github/copilot-instructions.md` → *Releasing — promoting `dev` → `main`* for the full checklist. Quick reference:
+  - Bump `manifest.json` to the next **minor** before the release PR (`1.1.8` → `1.2.0`, `1.2.2` → `1.3.0`, `1.5.7` → `1.6.0`; reset patch to `0`). Land that bump via a normal `chore/release-…` PR into `dev` first.
+  - Open the release PR titled `release: vX.Y.0 — <summary>` against `main`; wait for CI + Copilot review submitted, resolve comments.
+  - **Merge with a merge commit (`--merge`, NOT squash)** so the dev PR history is preserved on `main`. `release.yml` then publishes the stable `vX.Y.0` GitHub Release.
+  - Major bumps (`1.x.y` → `2.0.0`) require explicit user approval.
 
 ## BLE Frame Format
 

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -18,6 +18,7 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
 - **PR review gate:** Always wait for the Copilot code reviewer to *actually submit* its review (not just the workflow run to finish) before merging. The review comments arrive asynchronously after the "Request Copilot Code Review" workflow turns green. Verify with `gh pr view <N> --json reviews` and address every comment before merge.
 - **Post-merge:** After merging to `dev`, verify the `Pre-release` workflow produced a new `v<version>-dev.<timestamp>` GitHub release; this is what HACS beta-testers install.
+- **Releasing dev → main:** Each `dev` → `main` promotion is a stable release and **must** bump `manifest.json` to the next **minor** (e.g. `1.1.8` → `1.2.0`, `1.2.2` → `1.3.0`, `1.5.7` → `1.6.0`; reset patch to `0`). The version bump goes onto `dev` first (via a normal PR), then open the release PR `dev` → `main` titled `release: vX.Y.0 — …`, wait for CI + Copilot review submitted, resolve comments, and **merge with a merge commit (`--merge`, NOT squash)** so the dev PR history is preserved. `release.yml` then publishes the stable `vX.Y.0` GitHub Release. Major bumps (`1.x.y` → `2.0.0`) are reserved for breaking changes and need explicit user approval.
 
 ## BLE Frame Format
 


### PR DESCRIPTION
## Summary

Codifies the release-versioning rule the user requested: every `dev` → `main`
promotion bumps `manifest.json` to the **next minor** (patch reset to `0`).

- `1.1.8` → `1.2.0`
- `1.2.2` → `1.3.0`
- `1.5.7` → `1.6.0`

Patch versions remain reserved for the pre-release/HACS beta channel
generated from each dev PR. Major bumps (`1.x.y` → `2.0.0`) are reserved
for breaking changes and require explicit user approval.

## Files updated

- **`.github/copilot-instructions.md`** — adds a full *"Releasing — promoting `dev` → `main`"* section with the semver rule, a release-PR checklist, and reaffirms `--merge` over squash to preserve dev PR history.
- **`.github/instructions/petkit-ble.instructions.md`** — one-line mirror so the per-file instructions catch the rule too.

No code changes.