### PR TITLE
fix(ctw3): persist daily drink-event counter and reset at local midnight

### DIFF
--- a/custom_components/petkit_ble/__init__.py
+++ b/custom_components/petkit_ble/__init__.py
@@ -70,6 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     coordinator = PetkitBleCoordinator(hass, entry)
+    await coordinator.async_load_persistent_state()
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.bluetooth import (
@@ -20,6 +20,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.core import callback
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
@@ -130,12 +131,18 @@ async def _load_drink_state_into(state: _DrinkCountState, store: Any) -> None:
     if not stored:
         return
     try:
-        state.count = int(stored.get("count", 0))
+        count = int(stored.get("count", 0))
         state.date_iso = str(stored.get("date") or state.date_iso)
     except (TypeError, ValueError) as exc:
         _LOGGER.debug("Discarding corrupt drink-count store: %s", exc)
         return
-    today_iso = date.today().isoformat()
+    # Defensive: a corrupt or hand-edited store could persist a negative
+    # count, which would surface as a negative sensor value. Discard it.
+    if count < 0:
+        _LOGGER.debug("Discarding negative drink-count from store: %d", count)
+        return
+    state.count = count
+    today_iso = dt_util.now().date().isoformat()
     if state.date_iso != today_iso:
         state.count = 0
         state.date_iso = today_iso
@@ -153,7 +160,7 @@ async def _track_drink_event_into(
     counter. Always writes the current count back onto ``data`` so the
     sensor reflects the latest value even when nothing changed.
     """
-    today_iso = date.today().isoformat()
+    today_iso = dt_util.now().date().isoformat()
     if today_iso != state.date_iso:
         _LOGGER.debug(
             "Daily drink-count rollover %s → %s (was %d)",
@@ -201,9 +208,12 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
 
         # Track drink events across polls. The state is held in a small
         # dataclass so the counting + persistence logic can live in free
-        # functions (testable without the full coordinator chain).
-        self._drink_state = _DrinkCountState(date_iso=date.today().isoformat())
-        self._drink_store: Store = Store(hass, version=1, key=f"{DOMAIN}_drink_count_{self._address.lower()}")
+        # functions (testable without the full coordinator chain). The
+        # storage key uses ``config_entry.entry_id`` rather than the raw
+        # MAC because storage keys map to filenames under ``.storage/``
+        # and colons are invalid on some filesystems (notably Windows).
+        self._drink_state = _DrinkCountState(date_iso=dt_util.now().date().isoformat())
+        self._drink_store: Store = Store(hass, version=1, key=f"{DOMAIN}_drink_count_{config_entry.entry_id}")
 
         # Cache for settings fields (CMD 211 / CMD 221). See _SETTINGS_FIELDS
         # docstring for rationale. Populated either by a successful CMD 211

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import timedelta
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.bluetooth import (
     BluetoothChange,
@@ -17,6 +18,7 @@ from homeassistant.components.bluetooth import (
     async_scanner_count,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 if TYPE_CHECKING:
@@ -97,6 +99,87 @@ def _reconcile_settings_into(
     return warned
 
 
+@dataclass
+class _DrinkCountState:
+    """Mutable holder for the daily drink-event counter.
+
+    Lives on the coordinator across polls. Extracted into a small
+    dataclass so the counting and persistence logic can be unit-tested
+    via free functions (``_track_drink_event_into`` /
+    ``_load_drink_state_into``) without instantiating the full
+    ``DataUpdateCoordinator`` chain (which is awkward to mock).
+    """
+
+    prev_detect_status: int | None = None
+    count: int = 0
+    date_iso: str = ""
+
+
+async def _load_drink_state_into(state: _DrinkCountState, store: Any) -> None:
+    """Populate ``state`` from a ``Store`` snapshot if one exists.
+
+    Storage failures are swallowed at debug level — they must never block
+    integration setup. A persisted count from a previous day is dropped so
+    today's counter starts from zero.
+    """
+    try:
+        stored = await store.async_load()
+    except Exception as exc:
+        _LOGGER.debug("Failed to load drink-count store: %s", exc)
+        return
+    if not stored:
+        return
+    try:
+        state.count = int(stored.get("count", 0))
+        state.date_iso = str(stored.get("date") or state.date_iso)
+    except (TypeError, ValueError) as exc:
+        _LOGGER.debug("Discarding corrupt drink-count store: %s", exc)
+        return
+    today_iso = date.today().isoformat()
+    if state.date_iso != today_iso:
+        state.count = 0
+        state.date_iso = today_iso
+
+
+async def _track_drink_event_into(
+    state: _DrinkCountState,
+    store: Any,
+    data: PetkitFountainData,
+) -> None:
+    """Update ``state`` from a freshly polled ``data``; persist on change.
+
+    Increments on a ``detect_status`` 0 → 1 transition. Resets the counter
+    when the local date rolls over so the sensor is genuinely a per-day
+    counter. Always writes the current count back onto ``data`` so the
+    sensor reflects the latest value even when nothing changed.
+    """
+    today_iso = date.today().isoformat()
+    if today_iso != state.date_iso:
+        _LOGGER.debug(
+            "Daily drink-count rollover %s → %s (was %d)",
+            state.date_iso,
+            today_iso,
+            state.count,
+        )
+        state.date_iso = today_iso
+        state.count = 0
+
+    cur_detect = data.detect_status
+    count_changed = False
+    if state.prev_detect_status is not None and state.prev_detect_status == 0 and cur_detect == 1:
+        state.count += 1
+        count_changed = True
+        _LOGGER.debug("Drink event detected (count=%d)", state.count)
+    state.prev_detect_status = cur_detect
+    data.drink_event_count = state.count
+
+    if count_changed:
+        try:
+            await store.async_save({"count": state.count, "date": state.date_iso})
+        except Exception as exc:
+            _LOGGER.debug("Failed to persist drink-count store: %s", exc)
+
+
 class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
     """Coordinator that polls a Petkit fountain over BLE."""
 
@@ -116,9 +199,11 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             _LOGGER.warning("Corrupted device secret for %s, treating as None", self._address)
             self._secret = None
 
-        # Track drink events across polls
-        self._prev_detect_status: int | None = None
-        self._drink_event_count: int = 0
+        # Track drink events across polls. The state is held in a small
+        # dataclass so the counting + persistence logic can live in free
+        # functions (testable without the full coordinator chain).
+        self._drink_state = _DrinkCountState(date_iso=date.today().isoformat())
+        self._drink_store: Store = Store(hass, version=1, key=f"{DOMAIN}_drink_count_{self._address.lower()}")
 
         # Cache for settings fields (CMD 211 / CMD 221). See _SETTINGS_FIELDS
         # docstring for rationale. Populated either by a successful CMD 211
@@ -132,6 +217,18 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             name=f"{DOMAIN}_{self._address}",
             update_interval=timedelta(seconds=POLL_INTERVAL),
         )
+
+    async def async_load_persistent_state(self) -> None:
+        """Load the persisted drink-event counter from disk.
+
+        Called once before the first refresh so a Home Assistant restart or
+        integration reload no longer wipes today's count to zero.
+        """
+        await _load_drink_state_into(self._drink_state, self._drink_store)
+
+    async def _track_drink_event(self, data: PetkitFountainData) -> None:
+        """Thin wrapper around ``_track_drink_event_into`` for the poll loop."""
+        await _track_drink_event_into(self._drink_state, self._drink_store, data)
 
     def _log_unreachable_diagnostics(self) -> None:
         """Emit a single diagnostic log line explaining why the device is not connectable.
@@ -289,14 +386,9 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
                 data={**self._config_entry.data, CONF_MODEL: data.alias},
             )
 
-        # Track drink events: detect_status transitions 0→1
-        # No pump check — in smart mode the pump may be off while pet drinks
-        cur_detect = data.detect_status
-        if self._prev_detect_status is not None and self._prev_detect_status == 0 and cur_detect == 1:
-            self._drink_event_count += 1
-            _LOGGER.debug("Drink event detected (count=%d)", self._drink_event_count)
-        self._prev_detect_status = cur_detect
-        data.drink_event_count = self._drink_event_count
+        # Track drink events. Counter resets daily and persists across
+        # restarts. See ``_track_drink_event`` for full rationale.
+        await self._track_drink_event(data)
 
         # RSSI from the most recent BLE advertisement (no connection required)
         service_info = async_last_service_info(self.hass, self._address, connectable=False)

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,8 @@ _HA_STUBS = [
     "homeassistant.helpers.entity_platform",
     "homeassistant.helpers.storage",
     "homeassistant.helpers.update_coordinator",
+    "homeassistant.util",
+    "homeassistant.util.dt",
     "bleak",
     "bleak.backends",
     "bleak.backends.device",
@@ -41,6 +43,16 @@ _HA_STUBS = [
 for mod_name in _HA_STUBS:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = MagicMock()
+
+# Make ``homeassistant.util.dt.now()`` behave like the real helper so date /
+# timezone-dependent code under test can call ``.date().isoformat()`` on it.
+# Stitch the parent attribute too: ``from homeassistant.util import dt as
+# dt_util`` resolves through the parent's attribute, not via sys.modules.
+import datetime as _datetime  # noqa: E402
+
+_dt_module = sys.modules["homeassistant.util.dt"]
+_dt_module.now = lambda: _datetime.datetime.now()
+sys.modules["homeassistant.util"].dt = _dt_module
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ _HA_STUBS = [
     "homeassistant.helpers",
     "homeassistant.helpers.device_registry",
     "homeassistant.helpers.entity_platform",
+    "homeassistant.helpers.storage",
     "homeassistant.helpers.update_coordinator",
     "bleak",
     "bleak.backends",

--- a/tests/test_drink_count.py
+++ b/tests/test_drink_count.py
@@ -8,6 +8,7 @@ Covers behaviour added in fix/ctw3-drink-events-counter:
 - The counter is persisted to ``Store`` and restored at startup, so a Home
   Assistant restart no longer wipes today's count.
 - A persisted count from a previous day is dropped on load.
+- A negative count from a corrupt store is rejected.
 
 Tests target the free functions ``_track_drink_event_into`` and
 ``_load_drink_state_into`` so the full ``DataUpdateCoordinator`` chain
@@ -39,12 +40,18 @@ def _make_store() -> MagicMock:
     return store
 
 
+@pytest.fixture
+def today_iso() -> str:
+    """Capture today's ISO date once per test to avoid midnight-rollover flakes."""
+    return date.today().isoformat()
+
+
 class TestEdgeDetection:
     """Counter increments on a 0 → 1 detect_status transition only."""
 
     @pytest.mark.asyncio
-    async def test_zero_to_one_increments_and_persists(self) -> None:
-        state = _DrinkCountState(prev_detect_status=0, date_iso=date.today().isoformat())
+    async def test_zero_to_one_increments_and_persists(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=0, date_iso=today_iso)
         store = _make_store()
 
         data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
@@ -52,11 +59,11 @@ class TestEdgeDetection:
 
         assert state.count == 1
         assert data.drink_event_count == 1
-        store.async_save.assert_awaited_once_with({"count": 1, "date": date.today().isoformat()})
+        store.async_save.assert_awaited_once_with({"count": 1, "date": today_iso})
 
     @pytest.mark.asyncio
-    async def test_steady_one_does_not_increment(self) -> None:
-        state = _DrinkCountState(prev_detect_status=1, date_iso=date.today().isoformat())
+    async def test_steady_one_does_not_increment(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=1, date_iso=today_iso)
         store = _make_store()
 
         data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
@@ -66,8 +73,8 @@ class TestEdgeDetection:
         store.async_save.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_one_to_zero_does_not_increment(self) -> None:
-        state = _DrinkCountState(prev_detect_status=1, date_iso=date.today().isoformat())
+    async def test_one_to_zero_does_not_increment(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=1, date_iso=today_iso)
         store = _make_store()
 
         data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
@@ -76,9 +83,9 @@ class TestEdgeDetection:
         assert state.count == 0
 
     @pytest.mark.asyncio
-    async def test_first_poll_initialises_without_counting(self) -> None:
+    async def test_first_poll_initialises_without_counting(self, today_iso: str) -> None:
         """A fresh state with prev=None must not count even if detect=1."""
-        state = _DrinkCountState(date_iso=date.today().isoformat())
+        state = _DrinkCountState(date_iso=today_iso)
         store = _make_store()
         assert state.prev_detect_status is None
 
@@ -93,20 +100,20 @@ class TestDailyReset:
     """Counter resets when the local date rolls over."""
 
     @pytest.mark.asyncio
-    async def test_rollover_resets_counter(self) -> None:
+    async def test_rollover_resets_counter(self, today_iso: str) -> None:
         state = _DrinkCountState(prev_detect_status=0, count=7, date_iso="2000-01-01")
         store = _make_store()
 
         data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
         await _track_drink_event_into(state, store, data)
 
-        assert state.date_iso == date.today().isoformat()
+        assert state.date_iso == today_iso
         assert state.count == 0
         assert data.drink_event_count == 0
 
     @pytest.mark.asyncio
-    async def test_same_day_keeps_counter(self) -> None:
-        state = _DrinkCountState(prev_detect_status=0, count=3, date_iso=date.today().isoformat())
+    async def test_same_day_keeps_counter(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=0, count=3, date_iso=today_iso)
         store = _make_store()
 
         data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
@@ -120,10 +127,9 @@ class TestPersistence:
     """Counter survives a Home Assistant restart via the Store helper."""
 
     @pytest.mark.asyncio
-    async def test_load_restores_today_count(self) -> None:
-        state = _DrinkCountState(date_iso=date.today().isoformat())
+    async def test_load_restores_today_count(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
         store = _make_store()
-        today_iso = date.today().isoformat()
         store.async_load = AsyncMock(return_value={"count": 12, "date": today_iso})
 
         await _load_drink_state_into(state, store)
@@ -132,19 +138,19 @@ class TestPersistence:
         assert state.date_iso == today_iso
 
     @pytest.mark.asyncio
-    async def test_load_drops_stale_count_from_previous_day(self) -> None:
-        state = _DrinkCountState(date_iso=date.today().isoformat())
+    async def test_load_drops_stale_count_from_previous_day(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
         store = _make_store()
         store.async_load = AsyncMock(return_value={"count": 99, "date": "2000-01-01"})
 
         await _load_drink_state_into(state, store)
 
         assert state.count == 0
-        assert state.date_iso == date.today().isoformat()
+        assert state.date_iso == today_iso
 
     @pytest.mark.asyncio
-    async def test_load_handles_missing_store(self) -> None:
-        state = _DrinkCountState(date_iso=date.today().isoformat())
+    async def test_load_handles_missing_store(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
         store = _make_store()
         store.async_load = AsyncMock(return_value=None)
 
@@ -153,8 +159,8 @@ class TestPersistence:
         assert state.count == 0
 
     @pytest.mark.asyncio
-    async def test_load_handles_corrupt_store(self) -> None:
-        state = _DrinkCountState(date_iso=date.today().isoformat())
+    async def test_load_handles_corrupt_store(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
         store = _make_store()
         store.async_load = AsyncMock(return_value={"count": "not-an-int", "date": None})
 
@@ -163,8 +169,19 @@ class TestPersistence:
         assert state.count == 0
 
     @pytest.mark.asyncio
-    async def test_load_swallows_storage_exceptions(self) -> None:
-        state = _DrinkCountState(date_iso=date.today().isoformat())
+    async def test_load_discards_negative_count(self, today_iso: str) -> None:
+        """A negative count from a corrupt store must not surface to the sensor."""
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"count": -5, "date": today_iso})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_load_swallows_storage_exceptions(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
         store = _make_store()
         store.async_load = AsyncMock(side_effect=RuntimeError("disk full"))
 
@@ -173,8 +190,8 @@ class TestPersistence:
         assert state.count == 0
 
     @pytest.mark.asyncio
-    async def test_save_failure_does_not_break_polling(self) -> None:
-        state = _DrinkCountState(prev_detect_status=0, date_iso=date.today().isoformat())
+    async def test_save_failure_does_not_break_polling(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=0, date_iso=today_iso)
         store = _make_store()
         store.async_save = AsyncMock(side_effect=RuntimeError("disk full"))
 

--- a/tests/test_drink_count.py
+++ b/tests/test_drink_count.py
@@ -1,0 +1,184 @@
+"""Tests for the daily drink-event counter and its persistence.
+
+Covers behaviour added in fix/ctw3-drink-events-counter:
+
+- ``_track_drink_event_into`` increments only on a ``detect_status`` 0 → 1
+  edge.
+- The counter resets to 0 when the local date rolls over.
+- The counter is persisted to ``Store`` and restored at startup, so a Home
+  Assistant restart no longer wipes today's count.
+- A persisted count from a previous day is dropped on load.
+
+Tests target the free functions ``_track_drink_event_into`` and
+``_load_drink_state_into`` so the full ``DataUpdateCoordinator`` chain
+does not need to be mocked (it inherits from a stubbed-out class and
+cannot be safely instantiated in tests).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.petkit_ble.ble_client import PetkitFountainData
+from custom_components.petkit_ble.const import ALIAS_CTW3
+from custom_components.petkit_ble.coordinator import (
+    _DrinkCountState,
+    _load_drink_state_into,
+    _track_drink_event_into,
+)
+
+
+def _make_store() -> MagicMock:
+    """Build a Store mock whose async methods are awaitable."""
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save = AsyncMock()
+    return store
+
+
+class TestEdgeDetection:
+    """Counter increments on a 0 → 1 detect_status transition only."""
+
+    @pytest.mark.asyncio
+    async def test_zero_to_one_increments_and_persists(self) -> None:
+        state = _DrinkCountState(prev_detect_status=0, date_iso=date.today().isoformat())
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 1
+        assert data.drink_event_count == 1
+        store.async_save.assert_awaited_once_with({"count": 1, "date": date.today().isoformat()})
+
+    @pytest.mark.asyncio
+    async def test_steady_one_does_not_increment(self) -> None:
+        state = _DrinkCountState(prev_detect_status=1, date_iso=date.today().isoformat())
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 0
+        store.async_save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_one_to_zero_does_not_increment(self) -> None:
+        state = _DrinkCountState(prev_detect_status=1, date_iso=date.today().isoformat())
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_first_poll_initialises_without_counting(self) -> None:
+        """A fresh state with prev=None must not count even if detect=1."""
+        state = _DrinkCountState(date_iso=date.today().isoformat())
+        store = _make_store()
+        assert state.prev_detect_status is None
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 0
+        assert state.prev_detect_status == 1
+
+
+class TestDailyReset:
+    """Counter resets when the local date rolls over."""
+
+    @pytest.mark.asyncio
+    async def test_rollover_resets_counter(self) -> None:
+        state = _DrinkCountState(prev_detect_status=0, count=7, date_iso="2000-01-01")
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.date_iso == date.today().isoformat()
+        assert state.count == 0
+        assert data.drink_event_count == 0
+
+    @pytest.mark.asyncio
+    async def test_same_day_keeps_counter(self) -> None:
+        state = _DrinkCountState(prev_detect_status=0, count=3, date_iso=date.today().isoformat())
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 3
+        assert data.drink_event_count == 3
+
+
+class TestPersistence:
+    """Counter survives a Home Assistant restart via the Store helper."""
+
+    @pytest.mark.asyncio
+    async def test_load_restores_today_count(self) -> None:
+        state = _DrinkCountState(date_iso=date.today().isoformat())
+        store = _make_store()
+        today_iso = date.today().isoformat()
+        store.async_load = AsyncMock(return_value={"count": 12, "date": today_iso})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 12
+        assert state.date_iso == today_iso
+
+    @pytest.mark.asyncio
+    async def test_load_drops_stale_count_from_previous_day(self) -> None:
+        state = _DrinkCountState(date_iso=date.today().isoformat())
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"count": 99, "date": "2000-01-01"})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+        assert state.date_iso == date.today().isoformat()
+
+    @pytest.mark.asyncio
+    async def test_load_handles_missing_store(self) -> None:
+        state = _DrinkCountState(date_iso=date.today().isoformat())
+        store = _make_store()
+        store.async_load = AsyncMock(return_value=None)
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_load_handles_corrupt_store(self) -> None:
+        state = _DrinkCountState(date_iso=date.today().isoformat())
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"count": "not-an-int", "date": None})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_load_swallows_storage_exceptions(self) -> None:
+        state = _DrinkCountState(date_iso=date.today().isoformat())
+        store = _make_store()
+        store.async_load = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        # Must not raise — storage failures should never block setup.
+        await _load_drink_state_into(state, store)
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_save_failure_does_not_break_polling(self) -> None:
+        state = _DrinkCountState(prev_detect_status=0, date_iso=date.today().isoformat())
+        store = _make_store()
+        store.async_save = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        # Must not raise — storage failures must not break the poll loop.
+        await _track_drink_event_into(state, store, data)
+        assert state.count == 1


### PR DESCRIPTION
## Summary

Fixes the `Drink events today` (`Drinkgebeurtenissen vandaag`) sensor on
CTW3 fountains, which was reported to never increment.

The counter was an in-memory coordinator field with two bugs:

1. **Lost on restart** — every Home Assistant restart or integration reload reset it to 0.
2. **Never reset at midnight** — despite the `today` / `vandaag` label, it was effectively a lifetime counter.

In combination these made the sensor look stuck at zero in normal use.

## Changes

- Move counting state into a small `_DrinkCountState` dataclass and two
  free helpers (`_load_drink_state_into`, `_track_drink_event_into`),
  mirroring the testable pattern introduced in #64.
- Persist `{count, date}` via `homeassistant.helpers.storage.Store`,
  keyed by MAC. Loaded once before the first refresh; saved on each
  increment.
- Reset to 0 when the local date rolls over during a poll.
- Drop persisted state on load when the stored date is not today.
- Storage failures (load / save) are caught and logged at debug level so
  a corrupt or unwritable store cannot block setup or break polling.

## Tests

12 new tests in `tests/test_drink_count.py` covering edge detection,
daily rollover, persistence (load + save), stale-day drop, missing
store, corrupt store, and storage exceptions. Total suite: **80 passed**.

## Refs

Refs #65. Does **not** close it — the underlying question of why
`detect_status` reads `0` in every captured CMD 210 frame still needs a
ground-truth log captured while the pet is actively drinking. This PR
makes the counter behave correctly *whenever* `detect_status` does flip.

## Manifest

`1.1.10` → `1.1.11` (patch, dev pre-release).