### PR TITLE
fix(ctw3): silence per-poll CMD 211 timeout warning on CTW3

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -232,11 +232,18 @@ class PetkitBleClient:
         type_: int,
         data: list[int],
         timeout: float = 5.0,
+        *,
+        quiet: bool = False,
     ) -> bytes | None:
         """Send a command frame and wait for the matching response.
 
         Unsolicited notifications with a different cmd byte (e.g. CTW3 CMD 230
         extended state pushes) are discarded while waiting for the expected reply.
+
+        ``quiet=True`` demotes the per-poll timeout warning to DEBUG. Use it for
+        commands that are known to never reply on certain firmware revisions
+        (e.g. CMD 211 on CTW3 fw 111) so the log is not flooded; the higher
+        coordinator layer is responsible for surfacing the user-visible warning.
         """
         assert self._client is not None
         seq = self._next_seq()
@@ -245,15 +252,16 @@ class PetkitBleClient:
         _LOGGER.debug("TX CMD %d: %s", cmd, frame.hex())
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
+        log_timeout = _LOGGER.debug if quiet else _LOGGER.warning
         while True:
             remaining = deadline - loop.time()
             if remaining <= 0:
-                _LOGGER.warning("Timeout waiting for response to CMD %d", cmd)
+                log_timeout("Timeout waiting for response to CMD %d", cmd)
                 return None
             try:
                 raw = await asyncio.wait_for(self._rx_queue.get(), remaining)
             except TimeoutError:
-                _LOGGER.warning("Timeout waiting for response to CMD %d", cmd)
+                log_timeout("Timeout waiting for response to CMD %d", cmd)
                 return None
             parsed = self._parse_frame(raw)
             if parsed is None:
@@ -542,7 +550,13 @@ class PetkitBleClient:
                     self._parse_state_generic(data, payload_210)
 
             # CMD 211 — device config (settings)
-            payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [])
+            # CTW3 firmware 111 is known to never reply to CMD 211, so we
+            # demote the timeout to DEBUG for that alias to avoid flooding
+            # the log every minute. The coordinator still emits a single
+            # WARNING via _reconcile_settings_into() the first time, and
+            # the settings cache keeps user-set values intact across polls.
+            quiet_211 = data.alias in CTW3_ALIASES
+            payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [], quiet=quiet_211)
             if payload_211 is not None:
                 if data.alias in CTW3_ALIASES:
                     self._parse_config_ctw3(data, payload_211)

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
## Summary

CTW3 firmware 111 is confirmed to **never reply to CMD 211 (read
settings)**. This is true regardless of power mode (USB / battery) or
pump mode (continuous / smart) — verified against `home-assistant_petkit_ble_2026-05-01T08-00-09.240Z.log`,
which contains 50+ consecutive `Timeout waiting for response to CMD 211`
entries while the device was on USB power with the pump running
continuously.

The data side is already handled by the settings cache introduced in
#64 (`_reconcile_settings_into`): user-set values for smart cycle, LED,
DND, lock, etc. are preserved across polls even when CMD 211 never
replies. What was still wrong was the **log noise** — a `WARNING` line
on every single 60-second poll.

## Change

- Add a `quiet=True` kwarg to `PetkitBleClient._send_and_wait`. When
  set, the per-cmd timeout log is demoted from `WARNING` to `DEBUG`.
- Pass `quiet=True` for CMD 211 only when the device alias is in
  `CTW3_ALIASES`. W5 / CTW2 / W4X keep the existing `WARNING` because
  CMD 211 is expected to reply on those devices and a timeout there is
  a real problem.
- The coordinator still emits one user-visible `WARNING`
  (`_reconcile_settings_into`) the first time the cache is empty, so
  a genuine misconfiguration is not hidden.

## Tests

`81 passed` — no behaviour changes to test, only a log-level demotion.

## Manifest

`1.1.11` → `1.1.12` (patch, dev pre-release).