### PR TITLE
fix(ctw3): normalize detect_status so drink-counter increments (Closes #65)

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -404,7 +404,11 @@ class PetkitBleClient:
         data.filter_percent = payload[13]
         data.running_status = payload[14]
         data.pump_runtime_today = struct.unpack_from(">I", payload, 15)[0]
-        data.detect_status = payload[19]
+        # Normalize to 0/1: CTW3 firmware 111 has been observed to use
+        # value 2 (not 1) when the proximity sensor sees a pet. Treating any
+        # non-zero value as "detected" makes the field future-proof against
+        # other bit patterns (issue #65).
+        data.detect_status = 1 if payload[19] else 0
         data.supply_voltage_mv = struct.unpack_from(">h", payload, 20)[0]
         data.battery_voltage_mv = struct.unpack_from(">h", payload, 22)[0]
         data.battery_percent = payload[24]

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -180,6 +180,37 @@ class TestStateParsers:
         assert data.raw_state == sample_ctw3_state_payload
         assert data.state_tail == b""
 
+    def test_parse_state_ctw3_normalises_detect_status_value_2(self) -> None:
+        """CTW3 fw 111 emits ``0x02`` for "pet detected", not ``0x01``.
+
+        Regression test for issue #65: captured at 13:59:08 in
+        ``Logs/home-assistant_petkit_ble_2026-05-01T12-01-29.952Z.log`` while
+        the cat was visibly drinking. Without normalisation the drink-event
+        counter never increments because it requires a strict 0 → 1 transition.
+        """
+        raw = bytes.fromhex("01010102000000000000246fe907010000b39f02141a10766400c5068508")
+        assert raw[19] == 0x02  # the smoking gun
+
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        PetkitBleClient._parse_state_ctw3(data, raw)
+
+        assert data.detect_status == 1, "detect_status must be normalised to 0/1; raw byte 19 was 0x02"
+
+    def test_parse_state_ctw3_detect_status_zero_when_clear(self) -> None:
+        """Counterpart of the above: byte 19 = 0x00 → detect_status stays 0.
+
+        Captured at 14:00:17 (just after the cat moved away) — the
+        ``0x02 -> 0x00`` transition on byte 19 is what the binary sensor
+        observes when the device clears the detection flag.
+        """
+        raw = bytes.fromhex("0101010200000000000024702f07010000b3e500141410736400c506c706")
+        assert raw[19] == 0x00
+
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        PetkitBleClient._parse_state_ctw3(data, raw)
+
+        assert data.detect_status == 0
+
     def test_parse_state_generic_does_not_set_state_tail(self, sample_generic_state_payload: bytes) -> None:
         """Non-CTW3 payloads never populate the CTW3-specific tail."""
         data = PetkitFountainData(alias=ALIAS_W5)

--- a/tests/test_drink_count.py
+++ b/tests/test_drink_count.py
@@ -199,3 +199,45 @@ class TestPersistence:
         # Must not raise — storage failures must not break the poll loop.
         await _track_drink_event_into(state, store, data)
         assert state.count == 1
+
+
+class TestParserToCounterEndToEnd:
+    """Parser + counter together must increment on real CTW3 fw 111 frames.
+
+    Regression test for issue #65. The captured log
+    ``Logs/home-assistant_petkit_ble_2026-05-01T12-01-29.952Z.log`` contains
+    a real drink event at 13:59 where byte 19 transitions ``0x00 -> 0x02 ->
+    0x00``. Before the parser was fixed to normalise non-zero bytes to 1,
+    the counter never saw a strict 0 → 1 edge and therefore never
+    incremented.
+    """
+
+    # Two real 30-byte CTW3 CMD 210 payloads from the captured log:
+    # 13:59:08 (cat drinks, byte19=0x02) and 14:00:17 (cat leaves, byte19=0x00).
+    DETECTED = bytes.fromhex("010101020000000000002470e907010000b39f02141a10766400c5068508")
+    IDLE_AFTER = bytes.fromhex("0101010200000000000024702f07010000b3e500141410736400c506c706")
+    # Synthesise the "before" idle frame from the captured "detected" frame
+    # by clearing byte 19 — the counter only cares about byte 19 transitions.
+    IDLE_BEFORE = bytes(bytearray(DETECTED)[:19] + b"\x00" + bytearray(DETECTED)[20:])
+
+    @pytest.mark.asyncio
+    async def test_real_drink_event_increments_counter(self, today_iso: str) -> None:
+        """Feed three real frames through parser+counter; expect count=1."""
+        from custom_components.petkit_ble.ble_client import PetkitBleClient
+
+        # Sanity: the captured frames really do flip byte 19 the way we think.
+        assert self.IDLE_BEFORE[19] == 0x00
+        assert self.DETECTED[19] == 0x02
+        assert self.IDLE_AFTER[19] == 0x00
+
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+
+        for raw in (self.IDLE_BEFORE, self.DETECTED, self.IDLE_AFTER):
+            data = PetkitFountainData(alias=ALIAS_CTW3)
+            PetkitBleClient._parse_state_ctw3(data, raw)
+            await _track_drink_event_into(state, store, data)
+
+        assert state.count == 1, (
+            "One drink event observed → counter must read 1; regression for issue #65 (CTW3 fw 111 emits 0x02 not 0x01)"
+        )

--- a/tests/test_drink_count.py
+++ b/tests/test_drink_count.py
@@ -212,13 +212,12 @@ class TestParserToCounterEndToEnd:
     incremented.
     """
 
-    # Two real 30-byte CTW3 CMD 210 payloads from the captured log:
-    # 13:59:08 (cat drinks, byte19=0x02) and 14:00:17 (cat leaves, byte19=0x00).
+    # Three real 30-byte CTW3 CMD 210 payloads from the captured log:
+    # 13:58:00 (idle, byte19=0x00) → 13:59:08 (cat drinks, byte19=0x02) →
+    # 14:00:17 (cat leaves, byte19=0x00).
+    IDLE_BEFORE = bytes.fromhex("010101020000000000002470a507010000b35b00141a10736400c506c306")
     DETECTED = bytes.fromhex("010101020000000000002470e907010000b39f02141a10766400c5068508")
     IDLE_AFTER = bytes.fromhex("0101010200000000000024702f07010000b3e500141410736400c506c706")
-    # Synthesise the "before" idle frame from the captured "detected" frame
-    # by clearing byte 19 — the counter only cares about byte 19 transitions.
-    IDLE_BEFORE = bytes(bytearray(DETECTED)[:19] + b"\x00" + bytearray(DETECTED)[20:])
 
     @pytest.mark.asyncio
     async def test_real_drink_event_increments_counter(self, today_iso: str) -> None:


### PR DESCRIPTION
## Summary

The CTW3 fountain firmware 111 emits `0x02` on byte 19 of CMD 210 when the proximity sensor detects a pet, **not** `0x01`. The parser stored the raw byte, which had two effects:

- `binary_sensor.pet_drinks` toggled correctly because it uses `bool(detect_status)` (truthy for `2`) — that's why the binary sensor *did* work in the UI.
- `sensor.drink_events_today` requires a strict `0 → 1` edge in the coordinator, so it **never** incremented.

## Ground-truth evidence

Captured by the user in `Logs/home-assistant_petkit_ble_2026-05-01T12-01-29.952Z.log` while their cat Milka was drinking, with the diagnostic byte-diff log shipped in #68 enabled:

| Time     | Diff                          | Meaning              |
|----------|-------------------------------|----------------------|
| 13:59:13 | `byte[19]=0x00 -> 0x02`     | cat starts drinking  |
| 14:00:23 | `byte[19]=0x02 -> 0x00`     | cat leaves           |

## Fix

One-line change in `_parse_state_ctw3` (`ble_client.py`):

`python
data.detect_status = 1 if payload[19] else 0
`

Treating any non-zero byte 19 as "detected" also future-proofs the field against `0x03`/`0x04` etc. (likely a multi-bit status flag).

## Tests

Three new tests, all using real frames from the captured log:

- `test_parse_state_ctw3_normalises_detect_status_value_2` — parser test for the `byte[19]=0x02` frame at 13:59:08.
- `test_parse_state_ctw3_detect_status_zero_when_clear` — counterpart for the `byte[19]=0x00` frame at 14:00:17.
- `test_real_drink_event_increments_counter` — full parser-+-counter end-to-end run feeding three CTW3 30-byte payloads (idle → detected → idle), asserting `state.count` goes from 0 to 1.

94 / 94 tests pass; ruff + ruff format clean.

## Out of scope

Diagnostics from #68 (`state_tail_hex` sensor and byte-diff log) are left in place as reusable instrumentation for future offset investigations.

Closes #65, follows up #68.
