### PR TITLE
fix(ctw3): correct CMD 221 byte order - LED fields were off-by-one

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -453,16 +453,22 @@ class PetkitBleClient:
 
     @staticmethod
     def _parse_config_ctw3(data: PetkitFountainData, payload: bytes) -> None:
-        """Parse CMD 211 response for CTW3."""
+        """Parse CMD 211 response for CTW3.
+
+        Layout matches build_settings_payload_ctw3 (idx 6=dnd, 7=led_switch,
+        8=led_brightness, 9=child_lock). Note: CTW3 firmware 111 never
+        actually replies to CMD 211, so this parser is currently unreached
+        on real hardware but kept symmetric with the builder.
+        """
         if len(payload) < 9:
             return
         data.smart_time_on = payload[0]
         data.smart_time_off = payload[1]
         data.battery_work_time = struct.unpack_from(">H", payload, 2)[0]
         data.battery_sleep_time = struct.unpack_from(">H", payload, 4)[0]
-        data.led_switch = payload[6]
-        data.led_brightness = payload[7]
-        data.do_not_disturb_switch = payload[8]
+        data.do_not_disturb_switch = payload[6]
+        data.led_switch = payload[7]
+        data.led_brightness = payload[8]
         if len(payload) >= 10:
             data.is_locked = payload[9]
         data.config_loaded = True

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/protocol.py
+++ b/custom_components/petkit_ble/protocol.py
@@ -82,8 +82,16 @@ def build_settings_payload_ctw3(
     """Build the payload for CMD 221 (write settings) for CTW3 devices.
 
     Layout: [smart_work, smart_sleep, batt_work_hi, batt_work_lo,
-             batt_sleep_hi, batt_sleep_lo, led_switch, led_brightness,
-             dnd_enabled, child_lock]
+             batt_sleep_hi, batt_sleep_lo, dnd_enabled, led_switch,
+             led_brightness, child_lock]
+
+    Reverse-engineered from real-device CMD 221 captures:
+    confirmed user actions ``LED on -> brightness 1/8/9 -> LED off`` map
+    cleanly to ``payload[7] = led_switch`` and ``payload[8] = led_brightness``.
+    ``payload[6]`` is assumed to be ``dnd_enabled`` by analogy with the
+    generic (W5/CTW2) layout; this could not be exercised by the captures
+    (always 0) and may be re-validated when a CTW3 firmware response to
+    CMD 211 becomes available.
     """
     return [
         smart_work,
@@ -92,9 +100,9 @@ def build_settings_payload_ctw3(
         battery_work_time & 0xFF,
         (battery_sleep_time >> 8) & 0xFF,
         battery_sleep_time & 0xFF,
+        dnd_enabled,
         led_switch,
         led_brightness,
-        dnd_enabled,
         child_lock,
     ]
 

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -271,9 +271,9 @@ class TestStateParsers:
         buf[1] = 7  # smart_sleep
         struct.pack_into(">H", buf, 2, 300)  # battery_work_time
         struct.pack_into(">H", buf, 4, 600)  # battery_sleep_time
-        buf[6] = 1  # led_switch
-        buf[7] = 5  # led_brightness
-        buf[8] = 1  # dnd_enabled
+        buf[6] = 1  # dnd_enabled
+        buf[7] = 1  # led_switch
+        buf[8] = 5  # led_brightness
         buf[9] = 0  # child_lock
 
         data = PetkitFountainData(alias=ALIAS_CTW3)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -148,10 +148,112 @@ class TestBuildSettingsPayloadCTW3:
         # battery_sleep_time = 600 = 0x0258
         assert result[4] == 0x02
         assert result[5] == 0x58
-        assert result[6] == 1  # led_switch
-        assert result[7] == 8  # led_brightness
-        assert result[8] == 1  # dnd_enabled
+        assert result[6] == 1  # dnd_enabled
+        assert result[7] == 1  # led_switch
+        assert result[8] == 8  # led_brightness
         assert result[9] == 1  # child_lock
+
+    def test_real_device_payload_decoding(self) -> None:
+        """Regression: payloads captured from a real CTW3 (fw 111).
+
+        The user toggled LED on, adjusted brightness, then toggled LED off
+        between 18:52:13 and 18:52:48 in the 2026-05-03 debug log. After
+        rotating the byte layout, the led_switch / led_brightness fields
+        encoded by the integration must match the expected sequence.
+        """
+        cases = [
+            # (led_switch, led_brightness, expected payload[6..9])
+            (1, 1, [0, 1, 1, 0]),
+            (0, 5, [0, 0, 5, 0]),
+            (1, 8, [0, 1, 8, 0]),
+            (1, 9, [0, 1, 9, 0]),
+            (0, 8, [0, 0, 8, 0]),
+        ]
+        for led_switch, led_brightness, expected_tail in cases:
+            payload = build_settings_payload_ctw3(
+                smart_work=0,
+                smart_sleep=0,
+                led_switch=led_switch,
+                led_brightness=led_brightness,
+                dnd_enabled=0,
+                child_lock=0,
+            )
+            assert payload[6:10] == expected_tail, (
+                f"led_switch={led_switch}, brightness={led_brightness}: got {payload[6:10]}, expected {expected_tail}"
+            )
+
+
+class TestParseConfigCtw3:
+    """Round-trip tests for _parse_config_ctw3.
+
+    Real-device CMD 211 payloads are not available (CTW3 fw 111 never
+    replies), so we synthesise payloads identical to what
+    build_settings_payload_ctw3 emits and verify the parser populates the
+    matching fields. This pins parser/builder symmetry.
+    """
+
+    def test_roundtrip_real_device_sequence(self) -> None:
+        """Captured user actions (LED on -> brightness changes -> LED off)."""
+        from custom_components.petkit_ble.ble_client import (
+            PetkitBleClient,
+            PetkitFountainData,
+        )
+
+        cases = [
+            (1, 1),
+            (0, 5),
+            (1, 8),
+            (1, 9),
+            (0, 8),
+        ]
+        for led_switch, led_brightness in cases:
+            payload = bytes(
+                build_settings_payload_ctw3(
+                    smart_work=0,
+                    smart_sleep=0,
+                    led_switch=led_switch,
+                    led_brightness=led_brightness,
+                    dnd_enabled=0,
+                    child_lock=0,
+                )
+            )
+            data = PetkitFountainData(alias="CTW3")
+            PetkitBleClient._parse_config_ctw3(data, payload)
+            assert data.led_switch == led_switch
+            assert data.led_brightness == led_brightness
+            assert data.do_not_disturb_switch == 0
+            assert data.is_locked == 0
+
+    def test_roundtrip_with_dnd_and_lock(self) -> None:
+        """All four boolean-ish fields round-trip through builder + parser."""
+        from custom_components.petkit_ble.ble_client import (
+            PetkitBleClient,
+            PetkitFountainData,
+        )
+
+        payload = bytes(
+            build_settings_payload_ctw3(
+                smart_work=7,
+                smart_sleep=11,
+                battery_work_time=300,
+                battery_sleep_time=600,
+                led_switch=1,
+                led_brightness=6,
+                dnd_enabled=1,
+                child_lock=1,
+            )
+        )
+        data = PetkitFountainData(alias="CTW3")
+        PetkitBleClient._parse_config_ctw3(data, payload)
+        assert data.smart_time_on == 7
+        assert data.smart_time_off == 11
+        assert data.battery_work_time == 300
+        assert data.battery_sleep_time == 600
+        assert data.do_not_disturb_switch == 1
+        assert data.led_switch == 1
+        assert data.led_brightness == 6
+        assert data.is_locked == 1
+        assert data.config_loaded is True
 
 
 class TestBuildModePayload:

--- a/tests/test_settings_optimistic.py
+++ b/tests/test_settings_optimistic.py
@@ -39,9 +39,9 @@ class TestConfigLoadedFlag:
         data = PetkitFountainData(alias=ALIAS_CTW3)
         # CTW3 settings layout (10 bytes):
         # [smart_work, smart_sleep, batt_work_hi, batt_work_lo,
-        #  batt_sleep_hi, batt_sleep_lo, led_switch, led_brightness,
-        #  dnd_enabled, child_lock]
-        payload = bytes([10, 15, 0, 60, 0, 30, 1, 5, 0, 0])
+        #  batt_sleep_hi, batt_sleep_lo, dnd_enabled, led_switch,
+        #  led_brightness, child_lock]
+        payload = bytes([10, 15, 0, 60, 0, 30, 0, 1, 5, 0])
         PetkitBleClient._parse_config_ctw3(data, payload)
         assert data.config_loaded is True
         assert data.led_switch == 1


### PR DESCRIPTION
## Problem

When toggling the LED on a CTW3 fountain in Home Assistant, behaviour was inconsistent: the switch appeared to toggle but settings drifted, and the brightness slider didn't behave predictably. Captured CMD 221 frames in debug log  + "home-assistant_petkit_ble_2026-05-03T16-52-48.529Z.log" +  show the integration was writing fields at the wrong byte offsets.

## Evidence

User actions during 18:52:13 – 18:52:48: `LED on -> brightness 1/5/8/9 -> LED off`.

| # | Payload (bytes 6..9) |
|---|----------------------|
| 1 | `0 1 1 0` |
| 2 | `0 0 5 0` |
| 3 | `0 1 8 0` |
| 4 | `0 1 9 0` |
| 5 | `0 0 8 0` |

Under the previous layout (idx[6]=led_switch, idx[7]=led_brightness, idx[8]=dnd_enabled), led_switch was always 0 and dnd_enabled took values 1/5/8/9/8 — both impossible for the user actions performed. The pattern only makes sense if **led_switch is at idx 7 and led_brightness at idx 8**.

## Fix

Rotate three fields in `build_settings_payload_ctw3` and mirror the rotation in `_parse_config_ctw3`. New CTW3 layout:

` 
[smart_work, smart_sleep, batt_w_hi, batt_w_lo, batt_s_hi, batt_s_lo,
 dnd_enabled, led_switch, led_brightness, child_lock]
`

idx[6] is assumed to be `dnd_enabled` by analogy with the W5/CTW2 layout — the captures always show 0 there so this is documented as an assumption to revisit once a CTW3 firmware actually responds to CMD 211.

## Tests

- New builder regression test covering all 5 captured payloads.
- New parser round-trip test for the same sequence + a full-field test with DND/lock set.
- Updated 2 existing tests to the corrected layout.
- All 97 tests pass; ruff clean.

## Out of scope

- Stale-cache during brightness writes (frame 2 in the log) — partially addressed by #63's follow-up; revisit if this PR doesn't make LED stable on hardware.
- CMD 211 timeouts on CTW3 fw 111 — known firmware quirk, separate issue.
- LED on/off schedule times for CTW3 — not present in the 10-byte CMD 221 payload; entities are already hidden.

## Verification

After this is pre-released, please toggle the LED switch and adjust the brightness slider on the real CTW3 and confirm the LED state stays consistent.