### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.15",
+  "version": "1.2.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
Minor version bump for the upcoming dev->main release. Per repo convention, every dev->main merge bumps the minor version.