### PR TITLE
Release v1.2.0 - CTW3 LED + drink-counter fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -237,6 +237,51 @@ Even as admin (bypassed protection), direct pushes skip CI and break the audit t
 
 ---
 
+## Releasing — promoting `dev` → `main`
+
+When promoting `dev` to `main` for a stable release, the `manifest.json`
+version **must be bumped to a new minor**, never just published with the
+trailing dev patch number. Each merge of `dev` into `main` represents a
+batch of user-visible changes accumulated during the dev cycle, and minor
+versions are the right granularity for "shipped to all HACS users".
+
+### Versioning rule (semver, minor-on-release)
+
+- While working on `dev`, patch increments (`1.1.x`) are used for each
+  fix/feature PR — that's what the `Pre-release` workflow tags as
+  `v1.1.x-dev.<timestamp>` for HACS beta testers.
+- **Before** opening the release PR, land a normal `chore/release-…` PR
+  into `dev` that bumps `custom_components/petkit_ble/manifest.json` to
+  the next minor (patch reset to `0`):
+  - `1.1.8` → `1.2.0`
+  - `1.2.2` → `1.3.0`
+  - `1.5.7` → `1.6.0`
+
+  The release workflow reads the version from `manifest.json`, so the
+  bump must already be on `dev` HEAD when the release PR is merged into
+  `main`. Use the existing `chore/*` branch prefix — no new branch
+  category is introduced for this step.
+- **Major version bumps** (`1.x.y` → `2.0.0`) are reserved for breaking
+  changes to the integration's user-facing config or entity model and
+  must be discussed with the user first.
+
+### Release PR checklist
+
+1. On `dev`, bump `manifest.json` `version` to the next minor.
+2. Commit: `chore(release): bump version to vX.Y.0` and push (via a normal
+   PR to `dev` — never direct push).
+3. Open release PR: `gh pr create --base main --head dev --title
+   "release: vX.Y.0 — <summary>"`.
+4. Wait for CI green and the Copilot review **submitted** (same gate as
+   feature PRs).
+5. Resolve any review comments.
+6. **Merge with a merge commit** (`gh pr merge <N> --merge`), **never
+   squash** — the dev PR history must be preserved on `main`.
+7. Verify `release.yml` published a non-prerelease `vX.Y.0` GitHub
+   Release.
+
+---
+
 ## Code Conventions
 
 - **Language**: All code, comments, docstrings, commit messages, PR titles & descriptions, and GitHub issues MUST be in **English**. This applies even when the user/contributor communicates in another language — only the chat reply to the user may be in their language; everything that lands in the repository or on GitHub is English.

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -18,6 +18,11 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
 - **PR review gate:** Always wait for the Copilot code reviewer to *actually submit* its review (not just the workflow run to finish) before merging. The review comments arrive asynchronously after the "Request Copilot Code Review" workflow turns green. Verify with `gh pr view <N> --json reviews` and address every comment before merge.
 - **Post-merge:** After merging to `dev`, verify the `Pre-release` workflow produced a new `v<version>-dev.<timestamp>` GitHub release; this is what HACS beta-testers install.
+- **Releasing dev → main:** Each `dev` → `main` promotion is a stable release. See `.github/copilot-instructions.md` → *Releasing — promoting `dev` → `main`* for the full checklist. Quick reference:
+  - Bump `manifest.json` to the next **minor** before the release PR (`1.1.8` → `1.2.0`, `1.2.2` → `1.3.0`, `1.5.7` → `1.6.0`; reset patch to `0`). Land that bump via a normal `chore/release-…` PR into `dev` first.
+  - Open the release PR titled `release: vX.Y.0 — <summary>` against `main`; wait for CI + Copilot review submitted, resolve comments.
+  - **Merge with a merge commit (`--merge`, NOT squash)** so the dev PR history is preserved on `main`. `release.yml` then publishes the stable `vX.Y.0` GitHub Release.
+  - Major bumps (`1.x.y` → `2.0.0`) require explicit user approval.
 
 ## BLE Frame Format
 

--- a/custom_components/petkit_ble/__init__.py
+++ b/custom_components/petkit_ble/__init__.py
@@ -70,6 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     coordinator = PetkitBleCoordinator(hass, entry)
+    await coordinator.async_load_persistent_state()
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -453,16 +453,22 @@ class PetkitBleClient:
 
     @staticmethod
     def _parse_config_ctw3(data: PetkitFountainData, payload: bytes) -> None:
-        """Parse CMD 211 response for CTW3."""
+        """Parse CMD 211 response for CTW3.
+
+        Layout matches build_settings_payload_ctw3 (idx 6=dnd, 7=led_switch,
+        8=led_brightness, 9=child_lock). Note: CTW3 firmware 111 never
+        actually replies to CMD 211, so this parser is currently unreached
+        on real hardware but kept symmetric with the builder.
+        """
         if len(payload) < 9:
             return
         data.smart_time_on = payload[0]
         data.smart_time_off = payload[1]
         data.battery_work_time = struct.unpack_from(">H", payload, 2)[0]
         data.battery_sleep_time = struct.unpack_from(">H", payload, 4)[0]
-        data.led_switch = payload[6]
-        data.led_brightness = payload[7]
-        data.do_not_disturb_switch = payload[8]
+        data.do_not_disturb_switch = payload[6]
+        data.led_switch = payload[7]
+        data.led_brightness = payload[8]
         if len(payload) >= 10:
             data.is_locked = payload[9]
         data.config_loaded = True

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -113,6 +113,19 @@ class PetkitFountainData:
     battery_work_time: int = 0
     battery_sleep_time: int = 0
 
+    # Raw CMD 210 payload as last received. Kept so the coordinator can log
+    # a byte-by-byte diff between consecutive polls — a diagnostic aid for
+    # reverse-engineering CTW3 fields whose offsets are not yet known
+    # (notably ``detect_status``; see issue #65).
+    raw_state: bytes = b""
+
+    # Bytes 26..29 of the CTW3 30-byte CMD 210 payload. Currently unparsed
+    # — exposed via a hidden diagnostic sensor so users can graph their
+    # behaviour while we narrow down which byte carries the real
+    # ``detect_status``. Always empty for non-CTW3 devices and for older
+    # CTW3 firmware that returns only 26 bytes.
+    state_tail: bytes = b""
+
     # True once a CMD 211 (read settings) response has been parsed at least
     # once for this entry. Some firmware revisions never reply to CMD 211
     # (observed on CTW3 fw 111). When this flag is False, the cached
@@ -358,6 +371,11 @@ class PetkitBleClient:
         if len(payload) < 26:
             _LOGGER.warning("CTW3 state payload too short: %d bytes", len(payload))
             return
+        data.raw_state = bytes(payload)
+        # Bytes 26..29 are not yet decoded by this parser — see issue #65.
+        # Captured raw so the user (and future maintainers) can correlate
+        # them with observed pet-detection events via the diagnostic sensor.
+        data.state_tail = bytes(payload[26:30]) if len(payload) >= 30 else b""
         data.power_status = payload[0]
         data.suspend_status = payload[1]
         # The CTW3 firmware has been observed to transiently report mode=0 during
@@ -412,6 +430,7 @@ class PetkitBleClient:
         if len(payload) < 12:
             _LOGGER.warning("State payload too short: %d bytes", len(payload))
             return
+        data.raw_state = bytes(payload)
         data.power_status = payload[0]
         data.mode = payload[1]
         data.dnd_state = payload[2]

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -113,6 +113,15 @@ class PetkitFountainData:
     battery_work_time: int = 0
     battery_sleep_time: int = 0
 
+    # True once a CMD 211 (read settings) response has been parsed at least
+    # once for this entry. Some firmware revisions never reply to CMD 211
+    # (observed on CTW3 fw 111). When this flag is False, the cached
+    # settings fields are still at dataclass defaults — writing CMD 221
+    # would zero out smart-cycle / battery / DND / lock values on the
+    # device. protocol.build_full_settings_payload logs a one-shot warning
+    # in that case.
+    config_loaded: bool = False
+
     @property
     def is_ctw3(self) -> bool:
         """Return True if device uses the CTW3 extended state format."""
@@ -425,6 +434,7 @@ class PetkitBleClient:
         data.do_not_disturb_switch = payload[8]
         if len(payload) >= 10:
             data.is_locked = payload[9]
+        data.config_loaded = True
 
     @staticmethod
     def _parse_config_generic(data: PetkitFountainData, payload: bytes) -> None:
@@ -444,6 +454,7 @@ class PetkitBleClient:
             data.dnd_end_minutes = struct.unpack_from(">H", payload, 11)[0]
         if len(payload) >= 14:
             data.is_locked = payload[13]
+        data.config_loaded = True
 
     # ------------------------------------------------------------------
     # Device initialization (first-time setup only)

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -404,7 +404,11 @@ class PetkitBleClient:
         data.filter_percent = payload[13]
         data.running_status = payload[14]
         data.pump_runtime_today = struct.unpack_from(">I", payload, 15)[0]
-        data.detect_status = payload[19]
+        # Normalize to 0/1: CTW3 firmware 111 has been observed to use
+        # value 2 (not 1) when the proximity sensor sees a pet. Treating any
+        # non-zero value as "detected" makes the field future-proof against
+        # other bit patterns (issue #65).
+        data.detect_status = 1 if payload[19] else 0
         data.supply_voltage_mv = struct.unpack_from(">h", payload, 20)[0]
         data.battery_voltage_mv = struct.unpack_from(">h", payload, 22)[0]
         data.battery_percent = payload[24]

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -232,11 +232,18 @@ class PetkitBleClient:
         type_: int,
         data: list[int],
         timeout: float = 5.0,
+        *,
+        quiet: bool = False,
     ) -> bytes | None:
         """Send a command frame and wait for the matching response.
 
         Unsolicited notifications with a different cmd byte (e.g. CTW3 CMD 230
         extended state pushes) are discarded while waiting for the expected reply.
+
+        ``quiet=True`` demotes the per-poll timeout warning to DEBUG. Use it for
+        commands that are known to never reply on certain firmware revisions
+        (e.g. CMD 211 on CTW3 fw 111) so the log is not flooded; the higher
+        coordinator layer is responsible for surfacing the user-visible warning.
         """
         assert self._client is not None
         seq = self._next_seq()
@@ -245,15 +252,16 @@ class PetkitBleClient:
         _LOGGER.debug("TX CMD %d: %s", cmd, frame.hex())
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
+        log_timeout = _LOGGER.debug if quiet else _LOGGER.warning
         while True:
             remaining = deadline - loop.time()
             if remaining <= 0:
-                _LOGGER.warning("Timeout waiting for response to CMD %d", cmd)
+                log_timeout("Timeout waiting for response to CMD %d", cmd)
                 return None
             try:
                 raw = await asyncio.wait_for(self._rx_queue.get(), remaining)
             except TimeoutError:
-                _LOGGER.warning("Timeout waiting for response to CMD %d", cmd)
+                log_timeout("Timeout waiting for response to CMD %d", cmd)
                 return None
             parsed = self._parse_frame(raw)
             if parsed is None:
@@ -542,7 +550,13 @@ class PetkitBleClient:
                     self._parse_state_generic(data, payload_210)
 
             # CMD 211 — device config (settings)
-            payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [])
+            # CTW3 firmware 111 is known to never reply to CMD 211, so we
+            # demote the timeout to DEBUG for that alias to avoid flooding
+            # the log every minute. The coordinator still emits a single
+            # WARNING via _reconcile_settings_into() the first time, and
+            # the settings cache keeps user-set values intact across polls.
+            quiet_211 = data.alias in CTW3_ALIASES
+            payload_211 = await self._send_and_wait(CMD_GET_CONFIG, FRAME_TYPE_SEND, [], quiet=quiet_211)
             if payload_211 is not None:
                 if data.alias in CTW3_ALIASES:
                     self._parse_config_ctw3(data, payload_211)

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -30,11 +30,71 @@ from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMA
 
 _LOGGER = logging.getLogger(__name__)
 
+# Settings fields populated by CMD 211 and writable via CMD 221. When CMD 211
+# fails (e.g. CTW3 firmware 111 never responds to it), these would otherwise
+# stay at dataclass defaults and silently flip back after every poll, and any
+# CMD 221 write would zero out unrelated fields. We cache the last known value
+# of each on the coordinator and re-apply it onto fresh poll results so that
+# user writes persist across polls even when the device never replies to 211.
+_SETTINGS_FIELDS: tuple[str, ...] = (
+    "smart_time_on",
+    "smart_time_off",
+    "led_switch",
+    "led_brightness",
+    "do_not_disturb_switch",
+    "is_locked",
+    "battery_work_time",
+    "battery_sleep_time",
+    "led_on_minutes",
+    "led_off_minutes",
+    "dnd_start_minutes",
+    "dnd_end_minutes",
+)
+
 # How long to wait for a connectable advertisement before giving up. The proxy
 # emits adverts every ~500ms, but it can be unavailable for a few seconds while
 # it is mid-connect to another device. A 15s grace window covers that case
 # without significantly delaying genuine "device powered off" failures.
 CONNECTABLE_WAIT_TIMEOUT = 15.0
+
+
+def _reconcile_settings_into(
+    data: PetkitFountainData,
+    cache: dict[str, int],
+    *,
+    warned: bool,
+    name: str,
+    address: str,
+) -> bool:
+    """Pure helper for ``PetkitBleCoordinator._reconcile_settings``.
+
+    Mutates ``data`` and ``cache`` in place. Returns the new value of the
+    ``warned_no_config`` flag (True once we've emitted the warning).
+
+    Extracted as a free function so it can be unit-tested without
+    constructing a full coordinator (which inherits from
+    ``DataUpdateCoordinator`` and is awkward to instantiate).
+    """
+    if data.config_loaded:
+        for field in _SETTINGS_FIELDS:
+            cache[field] = getattr(data, field)
+        return warned
+    if cache:
+        for field, value in cache.items():
+            setattr(data, field, value)
+        data.config_loaded = True
+        return warned
+    if not warned:
+        _LOGGER.warning(
+            "CMD 211 (read settings) has not yet succeeded for %s (%s, alias=%s); "
+            "writing CMD 221 will use defaults for unread fields. The first "
+            "successful poll or user-driven write will populate the cache.",
+            name,
+            address,
+            data.alias,
+        )
+        return True
+    return warned
 
 
 class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
@@ -59,6 +119,12 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         # Track drink events across polls
         self._prev_detect_status: int | None = None
         self._drink_event_count: int = 0
+
+        # Cache for settings fields (CMD 211 / CMD 221). See _SETTINGS_FIELDS
+        # docstring for rationale. Populated either by a successful CMD 211
+        # parse or by an entity-driven write via apply_setting_optimistic().
+        self._settings_cache: dict[str, int] = {}
+        self._warned_no_config: bool = False
 
         super().__init__(
             hass,
@@ -202,6 +268,8 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             "Polled %s: power=%s mode=%s firmware=%s", self._name, data.power_status, data.mode, data.firmware
         )
 
+        self._reconcile_settings(data)
+
         # Self-heal persistence: if the BLE client inferred a corrected alias
         # from the CMD 210 payload (e.g. when the original entry stored a MAC
         # as CONF_MODEL), persist the corrected alias to the config entry so
@@ -237,6 +305,22 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
 
         return data
 
+    def _reconcile_settings(self, data: PetkitFountainData) -> None:
+        """Reconcile the settings cache with a freshly polled data object.
+
+        Each ``async_poll`` constructs a brand-new ``PetkitFountainData``, so
+        any settings that were not refreshed by a CMD 211 response would
+        revert to dataclass defaults — visibly flipping switches back in the
+        UI and zeroing unrelated fields on the next CMD 221 write.
+        """
+        self._warned_no_config = _reconcile_settings_into(
+            data,
+            self._settings_cache,
+            warned=self._warned_no_config,
+            name=self._name,
+            address=self._address,
+        )
+
     async def async_send_command(self, cmd: int, data: list[int]) -> bool:
         """Send a single BLE command, serialised with the poll lock.
 
@@ -254,3 +338,26 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
                 )
                 return False
             return await client.async_send_command(cmd, data, self._alias, self._secret)
+
+    @callback
+    def apply_setting_optimistic(self, field: str, value: int) -> None:
+        """Persist a CMD 221 write into the live data and the settings cache.
+
+        Entities call this after a successful CMD 221 so that:
+          1. The live ``coordinator.data`` reflects the new value immediately
+             (so the UI does not flip back while waiting for the next poll).
+          2. The cache survives the dataclass replacement performed by the
+             next ``async_poll`` call. ``_async_update_data`` re-applies the
+             cache when CMD 211 fails to populate the field naturally.
+
+        ``async_set_updated_data`` is invoked so listeners (entities) refresh
+        their state without waiting on a network round trip.
+        """
+        if field not in _SETTINGS_FIELDS:
+            _LOGGER.debug("apply_setting_optimistic: unknown field %r ignored", field)
+            return
+        self._settings_cache[field] = value
+        if self.data is not None:
+            setattr(self.data, field, value)
+            self.data.config_loaded = True
+            self.async_set_updated_data(self.data)

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.bluetooth import (
     BluetoothChange,
@@ -17,7 +18,9 @@ from homeassistant.components.bluetooth import (
     async_scanner_count,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
@@ -97,6 +100,93 @@ def _reconcile_settings_into(
     return warned
 
 
+@dataclass
+class _DrinkCountState:
+    """Mutable holder for the daily drink-event counter.
+
+    Lives on the coordinator across polls. Extracted into a small
+    dataclass so the counting and persistence logic can be unit-tested
+    via free functions (``_track_drink_event_into`` /
+    ``_load_drink_state_into``) without instantiating the full
+    ``DataUpdateCoordinator`` chain (which is awkward to mock).
+    """
+
+    prev_detect_status: int | None = None
+    count: int = 0
+    date_iso: str = ""
+
+
+async def _load_drink_state_into(state: _DrinkCountState, store: Any) -> None:
+    """Populate ``state`` from a ``Store`` snapshot if one exists.
+
+    Storage failures are swallowed at debug level — they must never block
+    integration setup. A persisted count from a previous day is dropped so
+    today's counter starts from zero.
+    """
+    try:
+        stored = await store.async_load()
+    except Exception as exc:
+        _LOGGER.debug("Failed to load drink-count store: %s", exc)
+        return
+    if not stored:
+        return
+    try:
+        count = int(stored.get("count", 0))
+        state.date_iso = str(stored.get("date") or state.date_iso)
+    except (TypeError, ValueError) as exc:
+        _LOGGER.debug("Discarding corrupt drink-count store: %s", exc)
+        return
+    # Defensive: a corrupt or hand-edited store could persist a negative
+    # count, which would surface as a negative sensor value. Discard it.
+    if count < 0:
+        _LOGGER.debug("Discarding negative drink-count from store: %d", count)
+        return
+    state.count = count
+    today_iso = dt_util.now().date().isoformat()
+    if state.date_iso != today_iso:
+        state.count = 0
+        state.date_iso = today_iso
+
+
+async def _track_drink_event_into(
+    state: _DrinkCountState,
+    store: Any,
+    data: PetkitFountainData,
+) -> None:
+    """Update ``state`` from a freshly polled ``data``; persist on change.
+
+    Increments on a ``detect_status`` 0 → 1 transition. Resets the counter
+    when the local date rolls over so the sensor is genuinely a per-day
+    counter. Always writes the current count back onto ``data`` so the
+    sensor reflects the latest value even when nothing changed.
+    """
+    today_iso = dt_util.now().date().isoformat()
+    if today_iso != state.date_iso:
+        _LOGGER.debug(
+            "Daily drink-count rollover %s → %s (was %d)",
+            state.date_iso,
+            today_iso,
+            state.count,
+        )
+        state.date_iso = today_iso
+        state.count = 0
+
+    cur_detect = data.detect_status
+    count_changed = False
+    if state.prev_detect_status is not None and state.prev_detect_status == 0 and cur_detect == 1:
+        state.count += 1
+        count_changed = True
+        _LOGGER.debug("Drink event detected (count=%d)", state.count)
+    state.prev_detect_status = cur_detect
+    data.drink_event_count = state.count
+
+    if count_changed:
+        try:
+            await store.async_save({"count": state.count, "date": state.date_iso})
+        except Exception as exc:
+            _LOGGER.debug("Failed to persist drink-count store: %s", exc)
+
+
 class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
     """Coordinator that polls a Petkit fountain over BLE."""
 
@@ -116,9 +206,14 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             _LOGGER.warning("Corrupted device secret for %s, treating as None", self._address)
             self._secret = None
 
-        # Track drink events across polls
-        self._prev_detect_status: int | None = None
-        self._drink_event_count: int = 0
+        # Track drink events across polls. The state is held in a small
+        # dataclass so the counting + persistence logic can live in free
+        # functions (testable without the full coordinator chain). The
+        # storage key uses ``config_entry.entry_id`` rather than the raw
+        # MAC because storage keys map to filenames under ``.storage/``
+        # and colons are invalid on some filesystems (notably Windows).
+        self._drink_state = _DrinkCountState(date_iso=dt_util.now().date().isoformat())
+        self._drink_store: Store = Store(hass, version=1, key=f"{DOMAIN}_drink_count_{config_entry.entry_id}")
 
         # Cache for settings fields (CMD 211 / CMD 221). See _SETTINGS_FIELDS
         # docstring for rationale. Populated either by a successful CMD 211
@@ -132,6 +227,18 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             name=f"{DOMAIN}_{self._address}",
             update_interval=timedelta(seconds=POLL_INTERVAL),
         )
+
+    async def async_load_persistent_state(self) -> None:
+        """Load the persisted drink-event counter from disk.
+
+        Called once before the first refresh so a Home Assistant restart or
+        integration reload no longer wipes today's count to zero.
+        """
+        await _load_drink_state_into(self._drink_state, self._drink_store)
+
+    async def _track_drink_event(self, data: PetkitFountainData) -> None:
+        """Thin wrapper around ``_track_drink_event_into`` for the poll loop."""
+        await _track_drink_event_into(self._drink_state, self._drink_store, data)
 
     def _log_unreachable_diagnostics(self) -> None:
         """Emit a single diagnostic log line explaining why the device is not connectable.
@@ -289,14 +396,9 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
                 data={**self._config_entry.data, CONF_MODEL: data.alias},
             )
 
-        # Track drink events: detect_status transitions 0→1
-        # No pump check — in smart mode the pump may be off while pet drinks
-        cur_detect = data.detect_status
-        if self._prev_detect_status is not None and self._prev_detect_status == 0 and cur_detect == 1:
-            self._drink_event_count += 1
-            _LOGGER.debug("Drink event detected (count=%d)", self._drink_event_count)
-        self._prev_detect_status = cur_detect
-        data.drink_event_count = self._drink_event_count
+        # Track drink events. Counter resets daily and persists across
+        # restarts. See ``_track_drink_event`` for full rationale.
+        await self._track_drink_event(data)
 
         # RSSI from the most recent BLE advertisement (no connection required)
         service_info = async_last_service_info(self.hass, self._address, connectable=False)

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -100,6 +100,40 @@ def _reconcile_settings_into(
     return warned
 
 
+# Byte indices in the CMD 210 payload that are known to change every poll
+# (running-uptime ms tick / sequence counter on CTW3 firmware 111). Excluded
+# from the diff log so the diff highlights only semantically-meaningful
+# changes — making it easy to spot which byte carries an event signal such
+# as pet-detection (see issue #65).
+_CTW3_NOISE_BYTES: frozenset[int] = frozenset(range(9, 19))
+
+
+def _diff_state_bytes(
+    prev: bytes,
+    curr: bytes,
+    *,
+    noisy: frozenset[int] = _CTW3_NOISE_BYTES,
+) -> list[tuple[int, int, int]]:
+    """Return ``(index, old, new)`` triples for bytes that changed.
+
+    Indices listed in ``noisy`` are skipped. When the two payloads have
+    different lengths the missing positions are treated as ``0x00`` so
+    appended/truncated bytes (e.g. the CTW3 tail at indices 26..29 that
+    appears only in 30-byte frames) are still reported.
+    """
+    if not prev:
+        return []
+    out: list[tuple[int, int, int]] = []
+    for i in range(max(len(prev), len(curr))):
+        if i in noisy:
+            continue
+        old = prev[i] if i < len(prev) else 0
+        new = curr[i] if i < len(curr) else 0
+        if old != new:
+            out.append((i, old, new))
+    return out
+
+
 @dataclass
 class _DrinkCountState:
     """Mutable holder for the daily drink-event counter.
@@ -220,6 +254,11 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         # parse or by an entity-driven write via apply_setting_optimistic().
         self._settings_cache: dict[str, int] = {}
         self._warned_no_config: bool = False
+
+        # Previous CMD 210 raw payload, kept so we can log a byte-by-byte
+        # diff between consecutive polls (see _diff_state_bytes). Used as a
+        # diagnostic aid for issue #65 (CTW3 detect_status offset unknown).
+        self._prev_raw_state: bytes = b""
 
         super().__init__(
             hass,
@@ -374,6 +413,27 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         _LOGGER.debug(
             "Polled %s: power=%s mode=%s firmware=%s", self._name, data.power_status, data.mode, data.firmware
         )
+
+        # Diagnostic: log changed bytes between consecutive CMD 210 polls.
+        # Only emitted when DEBUG logging is enabled. For CTW3, skip the
+        # noisy uptime/tick bytes 9..18 so the diff highlights semantic
+        # changes such as pet-detection events (issue #65). For W4/W5/CTW2
+        # the payload is only 12 bytes long and indices 9..11 carry
+        # meaningful state (pump_runtime tail, filter_percent,
+        # running_status) so we must not suppress them.
+        if _LOGGER.isEnabledFor(logging.DEBUG) and data.raw_state:
+            diff = _diff_state_bytes(
+                self._prev_raw_state,
+                data.raw_state,
+                noisy=_CTW3_NOISE_BYTES if data.is_ctw3 else frozenset(),
+            )
+            if diff:
+                _LOGGER.debug(
+                    "CMD 210 state diff for %s: %s",
+                    self._name,
+                    " ".join(f"byte[{i}]=0x{old:02x}->0x{new:02x}" for i, old, new in diff),
+                )
+            self._prev_raw_state = data.raw_state
 
         self._reconcile_settings(data)
 

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.15",
+  "version": "1.2.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/number.py
+++ b/custom_components/petkit_ble/number.py
@@ -127,9 +127,13 @@ class PetkitBleNumber(PetkitBleEntity, NumberEntity):
         data = self.coordinator.data
         if data is None:
             return
-        payload = build_full_settings_payload(data, **{self.entity_description.field_name: int(value)})
+        int_value = int(value)
+        payload = build_full_settings_payload(data, **{self.entity_description.field_name: int_value})
         success = await self.coordinator.async_send_command(CMD_WRITE_SETTINGS, payload)
         if success:
+            # Persist via coordinator-level cache so the value survives the
+            # next async_poll() (which constructs a fresh data object).
+            self.coordinator.apply_setting_optimistic(self.entity_description.field_name, int_value)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.error("Failed to set %s to %s", self.entity_description.key, value)

--- a/custom_components/petkit_ble/protocol.py
+++ b/custom_components/petkit_ble/protocol.py
@@ -82,8 +82,16 @@ def build_settings_payload_ctw3(
     """Build the payload for CMD 221 (write settings) for CTW3 devices.
 
     Layout: [smart_work, smart_sleep, batt_work_hi, batt_work_lo,
-             batt_sleep_hi, batt_sleep_lo, led_switch, led_brightness,
-             dnd_enabled, child_lock]
+             batt_sleep_hi, batt_sleep_lo, dnd_enabled, led_switch,
+             led_brightness, child_lock]
+
+    Reverse-engineered from real-device CMD 221 captures:
+    confirmed user actions ``LED on -> brightness 1/8/9 -> LED off`` map
+    cleanly to ``payload[7] = led_switch`` and ``payload[8] = led_brightness``.
+    ``payload[6]`` is assumed to be ``dnd_enabled`` by analogy with the
+    generic (W5/CTW2) layout; this could not be exercised by the captures
+    (always 0) and may be re-validated when a CTW3 firmware response to
+    CMD 211 becomes available.
     """
     return [
         smart_work,
@@ -92,9 +100,9 @@ def build_settings_payload_ctw3(
         battery_work_time & 0xFF,
         (battery_sleep_time >> 8) & 0xFF,
         battery_sleep_time & 0xFF,
+        dnd_enabled,
         led_switch,
         led_brightness,
-        dnd_enabled,
         child_lock,
     ]
 

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -135,6 +135,14 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         value_fn=lambda d: d.drink_event_count,
         available_fn=lambda d: d.is_ctw3,
     ),
+    PetkitSensorEntityDescription(
+        key="state_tail_hex",
+        translation_key="state_tail_hex",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda d: d.state_tail.hex() if d.state_tail else None,
+        available_fn=lambda d: d.is_ctw3 and bool(d.state_tail),
+    ),
 )
 
 

--- a/custom_components/petkit_ble/switch.py
+++ b/custom_components/petkit_ble/switch.py
@@ -123,6 +123,11 @@ class PetkitSettingsSwitch(PetkitBleEntity, SwitchEntity):
         payload = build_full_settings_payload(data, **{self._field_name: value})
         success = await self.coordinator.async_send_command(CMD_WRITE_SETTINGS, payload)
         if success:
+            # Persist the change in the coordinator's settings cache and live
+            # data so it survives the next async_poll() (which constructs a
+            # fresh PetkitFountainData) even on firmware revisions where
+            # CMD 211 never replies.
+            self.coordinator.apply_setting_optimistic(self._field_name, value)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.error("Failed to set %s to %d", self._field_name, value)

--- a/custom_components/petkit_ble/time.py
+++ b/custom_components/petkit_ble/time.py
@@ -120,6 +120,7 @@ class PetkitBleTime(PetkitBleEntity, TimeEntity):
         payload = build_full_settings_payload(data, **{self.entity_description.field_name: minutes})
         success = await self.coordinator.async_send_command(CMD_WRITE_SETTINGS, payload)
         if success:
+            self.coordinator.apply_setting_optimistic(self.entity_description.field_name, minutes)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.error("Failed to set %s", self.entity_description.key)

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -57,7 +57,8 @@
       "firmware": {"name": "Firmware"},
       "hardware_version": {"name": "Hardware Version"},
       "rssi": {"name": "Signal Strength"},
-      "drink_count": {"name": "Drink Events Today"}
+      "drink_count": {"name": "Drink Events Today"},
+      "state_tail_hex": {"name": "CTW3 State Tail (hex)"}
     },
     "binary_sensor": {
       "pump_running": {"name": "Pump Running"},

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -57,7 +57,8 @@
       "firmware": {"name": "Firmware"},
       "hardware_version": {"name": "Hardwareversie"},
       "rssi": {"name": "Signaalsterkte"},
-      "drink_count": {"name": "Drinkgebeurtenissen vandaag"}
+      "drink_count": {"name": "Drinkgebeurtenissen vandaag"},
+      "state_tail_hex": {"name": "CTW3 statestaart (hex)"}
     },
     "binary_sensor": {
       "pump_running": {"name": "Pomp actief"},

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -57,7 +57,8 @@
       "firmware": {"name": "Прошивка"},
       "hardware_version": {"name": "Версія апаратного забезпечення"},
       "rssi": {"name": "Рівень сигналу"},
-      "drink_count": {"name": "Випадки пиття сьогодні"}
+      "drink_count": {"name": "Випадки пиття сьогодні"},
+      "state_tail_hex": {"name": "Хвіст стану CTW3 (hex)"}
     },
     "binary_sensor": {
       "pump_running": {"name": "Насос працює"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,10 @@ _HA_STUBS = [
     "homeassistant.helpers",
     "homeassistant.helpers.device_registry",
     "homeassistant.helpers.entity_platform",
+    "homeassistant.helpers.storage",
     "homeassistant.helpers.update_coordinator",
+    "homeassistant.util",
+    "homeassistant.util.dt",
     "bleak",
     "bleak.backends",
     "bleak.backends.device",
@@ -40,6 +43,16 @@ _HA_STUBS = [
 for mod_name in _HA_STUBS:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = MagicMock()
+
+# Make ``homeassistant.util.dt.now()`` behave like the real helper so date /
+# timezone-dependent code under test can call ``.date().isoformat()`` on it.
+# Stitch the parent attribute too: ``from homeassistant.util import dt as
+# dt_util`` resolves through the parent's attribute, not via sys.modules.
+import datetime as _datetime  # noqa: E402
+
+_dt_module = sys.modules["homeassistant.util.dt"]
+_dt_module.now = lambda: _datetime.datetime.now()
+sys.modules["homeassistant.util"].dt = _dt_module
 
 
 @pytest.fixture

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -154,6 +154,39 @@ class TestStateParsers:
         PetkitBleClient._parse_state_ctw3(data, bytes(buf))
         assert data.mode == 1
 
+    def test_parse_state_ctw3_captures_state_tail_when_30_bytes(self) -> None:
+        """30-byte CTW3 payload populates state_tail and raw_state.
+
+        The ground-truth log captured for issue #65 contains 30-byte frames
+        whose trailing four bytes (26..29) are not yet decoded but vary
+        between idle and post-drink samples — see plan.md.
+        """
+        # Synthesised from real CTW3 fw 111 frame at 12:14:57:
+        # raw=01010102000000000000245787080100009b3d00141a10736400c506be06
+        raw = bytes.fromhex("01010102000000000000245787080100009b3d00141a10736400c506be06")
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        PetkitBleClient._parse_state_ctw3(data, raw)
+        assert data.raw_state == raw
+        assert data.state_tail == bytes.fromhex("c506be06")
+        # All previously-known fields keep their meaning
+        assert data.power_status == 1
+        assert data.battery_percent == 100
+        assert data.filter_percent == 8
+
+    def test_parse_state_ctw3_state_tail_empty_for_26_byte_payload(self, sample_ctw3_state_payload: bytes) -> None:
+        """Older CTW3 firmware returns 26 bytes with no trailing tail."""
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        PetkitBleClient._parse_state_ctw3(data, sample_ctw3_state_payload)
+        assert data.raw_state == sample_ctw3_state_payload
+        assert data.state_tail == b""
+
+    def test_parse_state_generic_does_not_set_state_tail(self, sample_generic_state_payload: bytes) -> None:
+        """Non-CTW3 payloads never populate the CTW3-specific tail."""
+        data = PetkitFountainData(alias=ALIAS_W5)
+        PetkitBleClient._parse_state_generic(data, sample_generic_state_payload)
+        assert data.raw_state == sample_generic_state_payload
+        assert data.state_tail == b""
+
     def test_parse_state_generic(self, sample_generic_state_payload: bytes) -> None:
         """Parse a generic state payload and verify fields."""
         data = PetkitFountainData(alias=ALIAS_W5)

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -271,9 +271,9 @@ class TestStateParsers:
         buf[1] = 7  # smart_sleep
         struct.pack_into(">H", buf, 2, 300)  # battery_work_time
         struct.pack_into(">H", buf, 4, 600)  # battery_sleep_time
-        buf[6] = 1  # led_switch
-        buf[7] = 5  # led_brightness
-        buf[8] = 1  # dnd_enabled
+        buf[6] = 1  # dnd_enabled
+        buf[7] = 1  # led_switch
+        buf[8] = 5  # led_brightness
         buf[9] = 0  # child_lock
 
         data = PetkitFountainData(alias=ALIAS_CTW3)

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -180,6 +180,37 @@ class TestStateParsers:
         assert data.raw_state == sample_ctw3_state_payload
         assert data.state_tail == b""
 
+    def test_parse_state_ctw3_normalises_detect_status_value_2(self) -> None:
+        """CTW3 fw 111 emits ``0x02`` for "pet detected", not ``0x01``.
+
+        Regression test for issue #65: captured at 13:59:08 in
+        ``Logs/home-assistant_petkit_ble_2026-05-01T12-01-29.952Z.log`` while
+        the cat was visibly drinking. Without normalisation the drink-event
+        counter never increments because it requires a strict 0 → 1 transition.
+        """
+        raw = bytes.fromhex("01010102000000000000246fe907010000b39f02141a10766400c5068508")
+        assert raw[19] == 0x02  # the smoking gun
+
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        PetkitBleClient._parse_state_ctw3(data, raw)
+
+        assert data.detect_status == 1, "detect_status must be normalised to 0/1; raw byte 19 was 0x02"
+
+    def test_parse_state_ctw3_detect_status_zero_when_clear(self) -> None:
+        """Counterpart of the above: byte 19 = 0x00 → detect_status stays 0.
+
+        Captured at 14:00:17 (just after the cat moved away) — the
+        ``0x02 -> 0x00`` transition on byte 19 is what the binary sensor
+        observes when the device clears the detection flag.
+        """
+        raw = bytes.fromhex("0101010200000000000024702f07010000b3e500141410736400c506c706")
+        assert raw[19] == 0x00
+
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        PetkitBleClient._parse_state_ctw3(data, raw)
+
+        assert data.detect_status == 0
+
     def test_parse_state_generic_does_not_set_state_tail(self, sample_generic_state_payload: bytes) -> None:
         """Non-CTW3 payloads never populate the CTW3-specific tail."""
         data = PetkitFountainData(alias=ALIAS_W5)

--- a/tests/test_drink_count.py
+++ b/tests/test_drink_count.py
@@ -199,3 +199,44 @@ class TestPersistence:
         # Must not raise — storage failures must not break the poll loop.
         await _track_drink_event_into(state, store, data)
         assert state.count == 1
+
+
+class TestParserToCounterEndToEnd:
+    """Parser + counter together must increment on real CTW3 fw 111 frames.
+
+    Regression test for issue #65. The captured log
+    ``Logs/home-assistant_petkit_ble_2026-05-01T12-01-29.952Z.log`` contains
+    a real drink event at 13:59 where byte 19 transitions ``0x00 -> 0x02 ->
+    0x00``. Before the parser was fixed to normalise non-zero bytes to 1,
+    the counter never saw a strict 0 → 1 edge and therefore never
+    incremented.
+    """
+
+    # Three real 30-byte CTW3 CMD 210 payloads from the captured log:
+    # 13:58:00 (idle, byte19=0x00) → 13:59:08 (cat drinks, byte19=0x02) →
+    # 14:00:17 (cat leaves, byte19=0x00).
+    IDLE_BEFORE = bytes.fromhex("010101020000000000002470a507010000b35b00141a10736400c506c306")
+    DETECTED = bytes.fromhex("010101020000000000002470e907010000b39f02141a10766400c5068508")
+    IDLE_AFTER = bytes.fromhex("0101010200000000000024702f07010000b3e500141410736400c506c706")
+
+    @pytest.mark.asyncio
+    async def test_real_drink_event_increments_counter(self, today_iso: str) -> None:
+        """Feed three real frames through parser+counter; expect count=1."""
+        from custom_components.petkit_ble.ble_client import PetkitBleClient
+
+        # Sanity: the captured frames really do flip byte 19 the way we think.
+        assert self.IDLE_BEFORE[19] == 0x00
+        assert self.DETECTED[19] == 0x02
+        assert self.IDLE_AFTER[19] == 0x00
+
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+
+        for raw in (self.IDLE_BEFORE, self.DETECTED, self.IDLE_AFTER):
+            data = PetkitFountainData(alias=ALIAS_CTW3)
+            PetkitBleClient._parse_state_ctw3(data, raw)
+            await _track_drink_event_into(state, store, data)
+
+        assert state.count == 1, (
+            "One drink event observed → counter must read 1; regression for issue #65 (CTW3 fw 111 emits 0x02 not 0x01)"
+        )

--- a/tests/test_drink_count.py
+++ b/tests/test_drink_count.py
@@ -1,0 +1,201 @@
+"""Tests for the daily drink-event counter and its persistence.
+
+Covers behaviour added in fix/ctw3-drink-events-counter:
+
+- ``_track_drink_event_into`` increments only on a ``detect_status`` 0 → 1
+  edge.
+- The counter resets to 0 when the local date rolls over.
+- The counter is persisted to ``Store`` and restored at startup, so a Home
+  Assistant restart no longer wipes today's count.
+- A persisted count from a previous day is dropped on load.
+- A negative count from a corrupt store is rejected.
+
+Tests target the free functions ``_track_drink_event_into`` and
+``_load_drink_state_into`` so the full ``DataUpdateCoordinator`` chain
+does not need to be mocked (it inherits from a stubbed-out class and
+cannot be safely instantiated in tests).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.petkit_ble.ble_client import PetkitFountainData
+from custom_components.petkit_ble.const import ALIAS_CTW3
+from custom_components.petkit_ble.coordinator import (
+    _DrinkCountState,
+    _load_drink_state_into,
+    _track_drink_event_into,
+)
+
+
+def _make_store() -> MagicMock:
+    """Build a Store mock whose async methods are awaitable."""
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save = AsyncMock()
+    return store
+
+
+@pytest.fixture
+def today_iso() -> str:
+    """Capture today's ISO date once per test to avoid midnight-rollover flakes."""
+    return date.today().isoformat()
+
+
+class TestEdgeDetection:
+    """Counter increments on a 0 → 1 detect_status transition only."""
+
+    @pytest.mark.asyncio
+    async def test_zero_to_one_increments_and_persists(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=0, date_iso=today_iso)
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 1
+        assert data.drink_event_count == 1
+        store.async_save.assert_awaited_once_with({"count": 1, "date": today_iso})
+
+    @pytest.mark.asyncio
+    async def test_steady_one_does_not_increment(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=1, date_iso=today_iso)
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 0
+        store.async_save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_one_to_zero_does_not_increment(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=1, date_iso=today_iso)
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_first_poll_initialises_without_counting(self, today_iso: str) -> None:
+        """A fresh state with prev=None must not count even if detect=1."""
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        assert state.prev_detect_status is None
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 0
+        assert state.prev_detect_status == 1
+
+
+class TestDailyReset:
+    """Counter resets when the local date rolls over."""
+
+    @pytest.mark.asyncio
+    async def test_rollover_resets_counter(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=0, count=7, date_iso="2000-01-01")
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.date_iso == today_iso
+        assert state.count == 0
+        assert data.drink_event_count == 0
+
+    @pytest.mark.asyncio
+    async def test_same_day_keeps_counter(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=0, count=3, date_iso=today_iso)
+        store = _make_store()
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=0)
+        await _track_drink_event_into(state, store, data)
+
+        assert state.count == 3
+        assert data.drink_event_count == 3
+
+
+class TestPersistence:
+    """Counter survives a Home Assistant restart via the Store helper."""
+
+    @pytest.mark.asyncio
+    async def test_load_restores_today_count(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"count": 12, "date": today_iso})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 12
+        assert state.date_iso == today_iso
+
+    @pytest.mark.asyncio
+    async def test_load_drops_stale_count_from_previous_day(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"count": 99, "date": "2000-01-01"})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+        assert state.date_iso == today_iso
+
+    @pytest.mark.asyncio
+    async def test_load_handles_missing_store(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        store.async_load = AsyncMock(return_value=None)
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_load_handles_corrupt_store(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"count": "not-an-int", "date": None})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_load_discards_negative_count(self, today_iso: str) -> None:
+        """A negative count from a corrupt store must not surface to the sensor."""
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"count": -5, "date": today_iso})
+
+        await _load_drink_state_into(state, store)
+
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_load_swallows_storage_exceptions(self, today_iso: str) -> None:
+        state = _DrinkCountState(date_iso=today_iso)
+        store = _make_store()
+        store.async_load = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        # Must not raise — storage failures should never block setup.
+        await _load_drink_state_into(state, store)
+        assert state.count == 0
+
+    @pytest.mark.asyncio
+    async def test_save_failure_does_not_break_polling(self, today_iso: str) -> None:
+        state = _DrinkCountState(prev_detect_status=0, date_iso=today_iso)
+        store = _make_store()
+        store.async_save = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        data = PetkitFountainData(alias=ALIAS_CTW3, detect_status=1)
+        # Must not raise — storage failures must not break the poll loop.
+        await _track_drink_event_into(state, store, data)
+        assert state.count == 1

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -148,10 +148,112 @@ class TestBuildSettingsPayloadCTW3:
         # battery_sleep_time = 600 = 0x0258
         assert result[4] == 0x02
         assert result[5] == 0x58
-        assert result[6] == 1  # led_switch
-        assert result[7] == 8  # led_brightness
-        assert result[8] == 1  # dnd_enabled
+        assert result[6] == 1  # dnd_enabled
+        assert result[7] == 1  # led_switch
+        assert result[8] == 8  # led_brightness
         assert result[9] == 1  # child_lock
+
+    def test_real_device_payload_decoding(self) -> None:
+        """Regression: payloads captured from a real CTW3 (fw 111).
+
+        The user toggled LED on, adjusted brightness, then toggled LED off
+        between 18:52:13 and 18:52:48 in the 2026-05-03 debug log. After
+        rotating the byte layout, the led_switch / led_brightness fields
+        encoded by the integration must match the expected sequence.
+        """
+        cases = [
+            # (led_switch, led_brightness, expected payload[6..9])
+            (1, 1, [0, 1, 1, 0]),
+            (0, 5, [0, 0, 5, 0]),
+            (1, 8, [0, 1, 8, 0]),
+            (1, 9, [0, 1, 9, 0]),
+            (0, 8, [0, 0, 8, 0]),
+        ]
+        for led_switch, led_brightness, expected_tail in cases:
+            payload = build_settings_payload_ctw3(
+                smart_work=0,
+                smart_sleep=0,
+                led_switch=led_switch,
+                led_brightness=led_brightness,
+                dnd_enabled=0,
+                child_lock=0,
+            )
+            assert payload[6:10] == expected_tail, (
+                f"led_switch={led_switch}, brightness={led_brightness}: got {payload[6:10]}, expected {expected_tail}"
+            )
+
+
+class TestParseConfigCtw3:
+    """Round-trip tests for _parse_config_ctw3.
+
+    Real-device CMD 211 payloads are not available (CTW3 fw 111 never
+    replies), so we synthesise payloads identical to what
+    build_settings_payload_ctw3 emits and verify the parser populates the
+    matching fields. This pins parser/builder symmetry.
+    """
+
+    def test_roundtrip_real_device_sequence(self) -> None:
+        """Captured user actions (LED on -> brightness changes -> LED off)."""
+        from custom_components.petkit_ble.ble_client import (
+            PetkitBleClient,
+            PetkitFountainData,
+        )
+
+        cases = [
+            (1, 1),
+            (0, 5),
+            (1, 8),
+            (1, 9),
+            (0, 8),
+        ]
+        for led_switch, led_brightness in cases:
+            payload = bytes(
+                build_settings_payload_ctw3(
+                    smart_work=0,
+                    smart_sleep=0,
+                    led_switch=led_switch,
+                    led_brightness=led_brightness,
+                    dnd_enabled=0,
+                    child_lock=0,
+                )
+            )
+            data = PetkitFountainData(alias="CTW3")
+            PetkitBleClient._parse_config_ctw3(data, payload)
+            assert data.led_switch == led_switch
+            assert data.led_brightness == led_brightness
+            assert data.do_not_disturb_switch == 0
+            assert data.is_locked == 0
+
+    def test_roundtrip_with_dnd_and_lock(self) -> None:
+        """All four boolean-ish fields round-trip through builder + parser."""
+        from custom_components.petkit_ble.ble_client import (
+            PetkitBleClient,
+            PetkitFountainData,
+        )
+
+        payload = bytes(
+            build_settings_payload_ctw3(
+                smart_work=7,
+                smart_sleep=11,
+                battery_work_time=300,
+                battery_sleep_time=600,
+                led_switch=1,
+                led_brightness=6,
+                dnd_enabled=1,
+                child_lock=1,
+            )
+        )
+        data = PetkitFountainData(alias="CTW3")
+        PetkitBleClient._parse_config_ctw3(data, payload)
+        assert data.smart_time_on == 7
+        assert data.smart_time_off == 11
+        assert data.battery_work_time == 300
+        assert data.battery_sleep_time == 600
+        assert data.do_not_disturb_switch == 1
+        assert data.led_switch == 1
+        assert data.led_brightness == 6
+        assert data.is_locked == 1
+        assert data.config_loaded is True
 
 
 class TestBuildModePayload:

--- a/tests/test_settings_optimistic.py
+++ b/tests/test_settings_optimistic.py
@@ -1,0 +1,146 @@
+"""Tests for the CMD 211/221 settings flow.
+
+Covers:
+- The ``config_loaded`` flag is False on a fresh PetkitFountainData and only
+  flips to True after a CMD 211 parser has run.
+- ``_reconcile_settings_into`` caches settings from a successful CMD 211 and
+  re-applies them onto fresh data objects when CMD 211 fails to respond.
+  This is the actual fix for the LED switch flip-back bug observed on CTW3
+  firmware 111 (CMD 211 never replies).
+- A one-shot WARNING is emitted on the first poll where CMD 211 fails AND
+  the cache is still empty.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from custom_components.petkit_ble.ble_client import (
+    PetkitBleClient,
+    PetkitFountainData,
+)
+from custom_components.petkit_ble.const import ALIAS_CTW3
+from custom_components.petkit_ble.coordinator import (
+    _SETTINGS_FIELDS,
+    _reconcile_settings_into,
+)
+
+
+class TestConfigLoadedFlag:
+    """The config_loaded flag tracks 'CMD 211 has worked at least once'."""
+
+    def test_default_is_false(self) -> None:
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        assert data.config_loaded is False
+
+    def test_ctw3_parser_sets_flag(self) -> None:
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        # CTW3 settings layout (10 bytes):
+        # [smart_work, smart_sleep, batt_work_hi, batt_work_lo,
+        #  batt_sleep_hi, batt_sleep_lo, led_switch, led_brightness,
+        #  dnd_enabled, child_lock]
+        payload = bytes([10, 15, 0, 60, 0, 30, 1, 5, 0, 0])
+        PetkitBleClient._parse_config_ctw3(data, payload)
+        assert data.config_loaded is True
+        assert data.led_switch == 1
+        assert data.led_brightness == 5
+
+    def test_ctw3_parser_short_payload_does_not_set_flag(self) -> None:
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        PetkitBleClient._parse_config_ctw3(data, b"\x00\x00")
+        assert data.config_loaded is False
+
+    def test_generic_parser_sets_flag(self) -> None:
+        data = PetkitFountainData(alias="W5")
+        payload = bytes([5, 10, 1, 3, 0, 60, 0, 120, 0, 0, 0, 0, 0, 0])
+        PetkitBleClient._parse_config_generic(data, payload)
+        assert data.config_loaded is True
+
+
+class TestReconcileSettingsInto:
+    """The coordinator preserves settings across polls when CMD 211 fails."""
+
+    def test_successful_poll_populates_cache(self) -> None:
+        cache: dict[str, int] = {}
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        data.config_loaded = True
+        data.led_switch = 1
+        data.led_brightness = 5
+        data.smart_time_on = 10
+        data.smart_time_off = 15
+        data.battery_work_time = 60
+        data.battery_sleep_time = 30
+
+        warned = _reconcile_settings_into(data, cache, warned=False, name="x", address="y")
+
+        assert warned is False
+        assert cache["led_switch"] == 1
+        assert cache["led_brightness"] == 5
+        assert cache["smart_time_on"] == 10
+        assert cache["battery_work_time"] == 60
+        for field in _SETTINGS_FIELDS:
+            assert field in cache
+
+    def test_failed_poll_with_cache_restores_values(self) -> None:
+        cache: dict[str, int] = {}
+        # Step 1: a successful poll populates the cache.
+        good = PetkitFountainData(alias=ALIAS_CTW3)
+        good.config_loaded = True
+        good.led_switch = 1
+        good.led_brightness = 7
+        good.smart_time_on = 20
+        _reconcile_settings_into(good, cache, warned=False, name="x", address="y")
+
+        # Step 2: a fresh data object simulating a poll where CMD 211 timed out.
+        fresh = PetkitFountainData(alias=ALIAS_CTW3)
+        assert fresh.config_loaded is False
+        assert fresh.led_switch == 0  # dataclass default
+
+        warned = _reconcile_settings_into(fresh, cache, warned=False, name="x", address="y")
+
+        # Cached values must have been re-applied.
+        assert fresh.led_switch == 1
+        assert fresh.led_brightness == 7
+        assert fresh.smart_time_on == 20
+        # The data object is now treated as configured so subsequent CMD 221
+        # writes do not zero out unrelated fields.
+        assert fresh.config_loaded is True
+        # The cache is non-empty so no warning is emitted.
+        assert warned is False
+
+    def test_failed_poll_without_cache_warns_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        cache: dict[str, int] = {}
+        fresh = PetkitFountainData(alias=ALIAS_CTW3)
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.petkit_ble.coordinator"):
+            warned = _reconcile_settings_into(fresh, cache, warned=False, name="x", address="y")
+        assert warned is True
+        assert any("CMD 211" in r.message for r in caplog.records)
+
+        # Second failure with warned=True must NOT re-warn.
+        caplog.clear()
+        fresh2 = PetkitFountainData(alias=ALIAS_CTW3)
+        with caplog.at_level(logging.WARNING, logger="custom_components.petkit_ble.coordinator"):
+            warned = _reconcile_settings_into(fresh2, cache, warned=True, name="x", address="y")
+        assert warned is True
+        assert not any("CMD 211" in r.message for r in caplog.records)
+
+    def test_user_write_into_cache_then_failed_poll_persists(self) -> None:
+        """``apply_setting_optimistic`` writes into the cache; the next failed
+        poll must restore the user-written value onto the fresh data object.
+
+        This is the end-to-end contract for the LED-flip-back fix: even on
+        firmware where CMD 211 never replies, a click on the LED switch
+        results in ``led_switch`` being preserved across every subsequent
+        coordinator refresh.
+        """
+        cache: dict[str, int] = {}
+        # Simulate apply_setting_optimistic("led_switch", 1).
+        cache["led_switch"] = 1
+
+        fresh = PetkitFountainData(alias=ALIAS_CTW3)
+        _reconcile_settings_into(fresh, cache, warned=False, name="x", address="y")
+        assert fresh.led_switch == 1
+        assert fresh.config_loaded is True

--- a/tests/test_settings_optimistic.py
+++ b/tests/test_settings_optimistic.py
@@ -39,9 +39,9 @@ class TestConfigLoadedFlag:
         data = PetkitFountainData(alias=ALIAS_CTW3)
         # CTW3 settings layout (10 bytes):
         # [smart_work, smart_sleep, batt_work_hi, batt_work_lo,
-        #  batt_sleep_hi, batt_sleep_lo, led_switch, led_brightness,
-        #  dnd_enabled, child_lock]
-        payload = bytes([10, 15, 0, 60, 0, 30, 1, 5, 0, 0])
+        #  batt_sleep_hi, batt_sleep_lo, dnd_enabled, led_switch,
+        #  led_brightness, child_lock]
+        payload = bytes([10, 15, 0, 60, 0, 30, 0, 1, 5, 0])
         PetkitBleClient._parse_config_ctw3(data, payload)
         assert data.config_loaded is True
         assert data.led_switch == 1

--- a/tests/test_state_diff.py
+++ b/tests/test_state_diff.py
@@ -1,0 +1,84 @@
+"""Tests for the CMD 210 byte-diff diagnostic helper."""
+
+from __future__ import annotations
+
+from custom_components.petkit_ble.coordinator import _diff_state_bytes
+
+
+class TestDiffStateBytes:
+    """Tests for the byte-diff helper used by the diagnostic poll log."""
+
+    def test_returns_empty_when_prev_is_empty(self) -> None:
+        """Initial poll has no previous frame to diff against."""
+        assert _diff_state_bytes(b"", b"\x01\x02") == []
+
+    def test_returns_empty_when_payloads_identical(self) -> None:
+        """No bytes changed → empty diff."""
+        payload = bytes.fromhex("01020304")
+        assert _diff_state_bytes(payload, payload) == []
+
+    def test_reports_changed_byte_with_old_and_new(self) -> None:
+        """Each diff entry is (index, old, new)."""
+        prev = bytes.fromhex("0008072307")
+        curr = bytes.fromhex("c506be0607")
+        # Indices 0..3 differ; index 4 is the same.
+        assert _diff_state_bytes(prev, curr) == [
+            (0, 0x00, 0xC5),
+            (1, 0x08, 0x06),
+            (2, 0x07, 0xBE),
+            (3, 0x23, 0x06),
+        ]
+
+    def test_skips_noisy_byte_indices(self) -> None:
+        """Bytes 9..18 (CTW3 uptime tick) are excluded from the diff."""
+        prev = bytearray(30)
+        curr = bytearray(30)
+        # Change bytes inside the noisy window — must NOT appear.
+        prev[10] = 0x01
+        curr[10] = 0xFF
+        prev[18] = 0x00
+        curr[18] = 0x42
+        # Change a byte outside the noisy window — MUST appear.
+        prev[26] = 0x08
+        curr[26] = 0xC5
+        diff = _diff_state_bytes(bytes(prev), bytes(curr))
+        assert diff == [(26, 0x08, 0xC5)]
+
+    def test_real_ctw3_frame_pair_highlights_byte_26(self) -> None:
+        """Real captured frames before/after a drink event.
+
+        Frames sourced from
+        ``Logs/home-assistant_petkit_ble_2026-05-01T10-15-53.221Z.log``.
+        With the noisy uptime bytes (9..18) suppressed, byte 26 jumping
+        from 0x08 to 0xc5 stands out as the strongest pet-detection
+        candidate (see plan.md / issue #65).
+        """
+        prev = bytes.fromhex("01010102000000000000242bfe080100006fb40014171076640008072307")
+        curr = bytes.fromhex("01010102000000000000245787080100009b3d00141a10736400c506be06")
+        diff = _diff_state_bytes(prev, curr)
+        # Diff must include byte 26 (0x08 -> 0xc5).
+        assert (26, 0x08, 0xC5) in diff
+        # And must exclude every byte inside the noisy uptime window.
+        assert all(i not in range(9, 19) for i, _, _ in diff)
+
+    def test_reports_appended_tail_bytes_when_payload_grows(self) -> None:
+        """If a poll returns more bytes than the previous one, the
+        appended indices must surface in the diff (treated as 0x00 -> new).
+
+        Guards the documented behaviour against a regression on CTW3
+        firmware revisions that may switch between 26- and 30-byte CMD 210
+        responses.
+        """
+        prev = bytes(range(20))  # 20 bytes
+        curr = prev + b"\xc5\x06\xbe\x06"  # 24 bytes
+        # Disable the noisy filter so this test exercises only the
+        # length-mismatch behaviour.
+        diff = _diff_state_bytes(prev, curr, noisy=frozenset())
+        assert diff == [(20, 0x00, 0xC5), (21, 0x00, 0x06), (22, 0x00, 0xBE), (23, 0x00, 0x06)]
+
+    def test_reports_truncated_tail_bytes_when_payload_shrinks(self) -> None:
+        """Symmetric guard for shrinking payloads — old bytes vs 0x00."""
+        prev = bytes([0x10, 0x20, 0x30, 0x40])
+        curr = bytes([0x10, 0x20])
+        diff = _diff_state_bytes(prev, curr, noisy=frozenset())
+        assert diff == [(2, 0x30, 0x00), (3, 0x40, 0x00)]


### PR DESCRIPTION
## Release v1.2.0

Promotes recent CTW3 fixes from dev to main. Per repo convention this is a minor bump (v1.1.9 -> v1.2.0).

### Changes since v1.1.9

- **#70** fix(ctw3): correct CMD 221 byte order - LED fields were off-by-one
- **#69** fix(ctw3): normalize detect_status so drink-counter increments (Closes #65)
- **#68** chore(ctw3): add diagnostics to pinpoint detect_status offset (Refs #65)
- **#67** fix(ctw3): silence per-poll CMD 211 timeout warning on CTW3
- **#66** fix(ctw3): persist daily drink-event counter and reset at local midnight
- **#64** fix(ctw3): keep LED switch on screen when CMD 211 never replies
- **#62** chore(docs): require minor version bump on dev->main release PRs

### Highlights

- LED switch + brightness on CTW3 now write to the correct CMD 221 byte offsets, fixing inconsistent toggle behaviour.
- Daily drink-event counter on CTW3 increments correctly and persists across HA restarts, with a midnight reset.
- CMD 211 timeout on CTW3 firmware 111 no longer floods the log every poll cycle.
- LED switch entity stays visible on CTW3 even when CMD 211 never replies.

### Verification

- 97/97 unit tests pass on dev.
- Ruff lint + format checks clean.
- HACS validation passing.

After merging, the release workflow will tag v1.2.0 and publish a GitHub Release automatically.