### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
## Summary
Bump manifest version 1.2.0 -> 1.3.0 ahead of the dev->main release.

This minor version batches the changes accumulated on dev (W4X unsupported-device handling #78, MIT LICENSE #80). The release workflow reads the version from manifest.json, so this must be on dev HEAD before the release PR to main is merged.

## Related
- Precedes the v1.3.0 release PR (dev -> main)