### PR TITLE
fix(i18n): complete fr.json translations

### DIFF
--- a/custom_components/petkit_ble/translations/fr.json
+++ b/custom_components/petkit_ble/translations/fr.json
@@ -16,6 +16,14 @@
       "init_device": {
         "title": "Initialiser l'appareil",
         "description": "L'appareil **{name}** doit être initialisé. Cela va enregistrer une clé secrète sur l'appareil. **Attention :** Après l'initialisation, l'application PetKit ne pourra plus se connecter à cet appareil. Vous devrez réinitialiser l'appareil aux paramètres d'usine pour rétablir l'accès à l'application."
+      },
+      "confirm_repair": {
+        "title": "Appareil déjà appairé",
+        "description": "**{name}** est déjà appairé — probablement avec l'application PetKit, ou avec une précédente configuration Home Assistant dont la clé secrète a été perdue. Pour le contrôler depuis Home Assistant, vous devez le ré-appairer avec une nouvelle clé secrète. Cela **remplace l'appairage existant** : l'application PetKit ne pourra plus se connecter tant que vous n'aurez pas réinitialisé la fontaine aux paramètres d'usine, et les deux ne peuvent pas la contrôler en même temps.",
+        "menu_options": {
+          "repair_confirm": "Ré-appairer maintenant (remplace l'appairage existant)",
+          "repair_cancel": "Annuler — laisser l'appareil intact"
+        }
       }
     },
     "error": {
@@ -29,6 +37,8 @@
       "already_configured": "Cet appareil est déjà configuré.",
       "no_devices_found": "Aucune fontaine Petkit n'a été trouvée.",
       "device_already_initialized": "Cet appareil est déjà initialisé avec une clé secrète. Veuillez d'abord le réinitialiser aux paramètres d'usine (retirez le module de commande, maintenez le bouton d'alimentation enfoncé pendant 3 secondes jusqu'à ce que les LEDs clignotent), puis réessayez.",
+      "repair_failed": "Impossible de ré-appairer l'appareil. Rapprochez-le et réessayez ; si l'échec persiste, réinitialisez-le aux paramètres d'usine (retirez le module de commande, maintenez le bouton d'alimentation enfoncé pendant 3 secondes jusqu'à ce que les LEDs clignotent), puis ajoutez-le à nouveau.",
+      "repair_cancelled": "Ré-appairage annulé. L'appareil a été laissé intact.",
       "unsupported_device": "Ce modèle d'appareil n'est peut-être pas entièrement pris en charge par cette intégration. Veuillez signaler ce problème sur GitHub en indiquant le modèle de votre appareil et les journaux."
     }
   },


### PR DESCRIPTION
## Summary
Completes the French translation file, which was missing keys present in en/nl/uk.

## Changes
- Add config.step.confirm_repair (title, description, menu_options)
- Add config.abort.repair_failed and config.abort.repair_cancelled

Verified fr.json now has no missing keys vs en.json.

## Related
- Closes #83
- Raised by Copilot review on release PR #82