### PR TITLE
feat(sensor): add instantaneous Power (W) sensor gated on AC power

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -147,6 +147,28 @@ class PetkitFountainData:
         return self.running_status == 1
 
     @property
+    def is_on_ac_power(self) -> bool:
+        """Return True when the fountain is powered from AC (mains).
+
+        AC-only models (W4/W5/CTW2) are always mains-powered. Battery-capable
+        models (CTW3) report ``electric_status == 2`` when running on AC.
+        """
+        if not self.is_ctw3:
+            return True
+        return self.electric_status == 2
+
+    @property
+    def power_w(self) -> float:
+        """Instantaneous power draw in watts.
+
+        Only reported while the pump is running and the device is on AC power;
+        on battery (CTW3) or when idle the draw from the mains is 0 W.
+        """
+        if not self.is_pump_running or not self.is_on_ac_power:
+            return 0.0
+        return POWER_COEFF_W.get(self.alias, DEFAULT_POWER_COEFF_W)
+
+    @property
     def filter_days_remaining(self) -> int:
         """Estimate remaining filter life in days."""
         if self.mode == 1:

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfPower,
     UnitOfTime,
     UnitOfVolume,
 )
@@ -90,6 +91,15 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLUME,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda d: round(d.water_purified_today_liters, 3),
+    ),
+    PetkitSensorEntityDescription(
+        key="power",
+        translation_key="power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda d: round(d.power_w, 3),
     ),
     PetkitSensorEntityDescription(
         key="energy_today",

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Battery Voltage"},
       "water_purified_today": {"name": "Water Purified Today"},
       "energy_today": {"name": "Energy Today"},
+      "power": {"name": "Power"},
       "energy_today_wh": {"name": "Energy Today (Wh)"},
       "filter_days_remaining": {"name": "Filter Days Remaining"},
       "firmware": {"name": "Firmware"},

--- a/custom_components/petkit_ble/translations/fr.json
+++ b/custom_components/petkit_ble/translations/fr.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Tension de la batterie"},
       "water_purified_today": {"name": "Eau purifiée aujourd'hui"},
       "energy_today": {"name": "Énergie aujourd'hui"},
+      "power": {"name": "Puissance"},
       "energy_today_wh": {"name": "Énergie aujourd'hui (Wh)"},
       "filter_days_remaining": {"name": "Jours restants avant changement du filtre"},
       "firmware": {"name": "Firmware"},

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Batterijspanning"},
       "water_purified_today": {"name": "Gezuiverd water vandaag"},
       "energy_today": {"name": "Energieverbruik vandaag"},
+      "power": {"name": "Vermogen"},
       "energy_today_wh": {"name": "Energieverbruik vandaag (Wh)"},
       "filter_days_remaining": {"name": "Resterende filterdagen"},
       "firmware": {"name": "Firmware"},

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Напруга батареї"},
       "water_purified_today": {"name": "Очищена вода сьогодні"},
       "energy_today": {"name": "Споживання енергії сьогодні"},
+      "power": {"name": "Потужність"},
       "energy_today_wh": {"name": "Споживання енергії сьогодні (Вт·год)"},
       "filter_days_remaining": {"name": "Залишилось днів фільтра"},
       "firmware": {"name": "Прошивка"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ _HA_STUBS = [
     "bleak",
     "bleak.backends",
     "bleak.backends.device",
+    "bleak.exc",
     "bleak_retry_connector",
     "voluptuous",
 ]

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -42,6 +42,54 @@ class TestIsPumpRunning:
         assert data.is_pump_running is False
 
 
+class TestIsOnAcPower:
+    """Tests for is_on_ac_power property."""
+
+    def test_ac_only_model_always_on_ac(self) -> None:
+        """AC-only models (non-CTW3) are always mains-powered regardless of electric_status."""
+        data = PetkitFountainData(alias=ALIAS_W5, electric_status=0)
+        assert data.is_on_ac_power is True
+
+    def test_ctw3_on_ac(self) -> None:
+        """CTW3 with electric_status == 2 is on AC."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, electric_status=2)
+        assert data.is_on_ac_power is True
+
+    def test_ctw3_on_battery(self) -> None:
+        """CTW3 with electric_status != 2 is on battery."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, electric_status=1)
+        assert data.is_on_ac_power is False
+
+
+class TestPowerW:
+    """Tests for power_w property."""
+
+    def test_running_on_ac_default(self) -> None:
+        """Pump running on AC → default coefficient (0.75 W)."""
+        data = PetkitFountainData(alias=ALIAS_W5, running_status=1)
+        assert data.power_w == pytest.approx(0.75)
+
+    def test_running_on_ac_w5c(self) -> None:
+        """W5C uses its specific coefficient (0.182 W)."""
+        data = PetkitFountainData(alias=ALIAS_W5C, running_status=1)
+        assert data.power_w == pytest.approx(0.182)
+
+    def test_not_running(self) -> None:
+        """Pump idle → 0 W even on AC."""
+        data = PetkitFountainData(alias=ALIAS_W5, running_status=0)
+        assert data.power_w == 0.0
+
+    def test_ctw3_on_battery(self) -> None:
+        """CTW3 running on battery (electric_status != 2) → 0 W from the mains."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, running_status=1, electric_status=1)
+        assert data.power_w == 0.0
+
+    def test_ctw3_running_on_ac(self) -> None:
+        """CTW3 running on AC → default coefficient."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, running_status=1, electric_status=2)
+        assert data.power_w == pytest.approx(0.75)
+
+
 class TestFilterDaysRemaining:
     """Tests for filter_days_remaining property."""
 


### PR DESCRIPTION
## What
Add an instantaneous **Power** sensor (W) alongside the existing energy (kWh) sensor.

## Why
Closes #89. When adding the fountain to the Energy dashboard the kWh sensor covers consumption, but there was no real-time power sensor. Per the user request, power is only meaningful when the device is connected to AC power.

## Behaviour
- `device_class=POWER`, unit `W`, `state_class=MEASUREMENT`, `suggested_display_precision=2`.
- Value = per-model coefficient (`POWER_COEFF_W`; 0.75 W default, 0.182 W for W5C) **only while the pump runs AND the device is on AC**; otherwise `0 W`.
- AC gating (`is_on_ac_power`): AC-only models (W4/W5/CTW2) are always mains-powered; CTW3 counts as AC only when `electric_status == 2` (0 W on battery).

## Changes
- `ble_client.py`: `is_on_ac_power` + `power_w` properties.
- `sensor.py`: `power` sensor description; `UnitOfPower` import.
- `translations/{en,fr,nl,uk}.json`: `power` name.

## Validation
- `ruff check` + `ruff format --check`: pass.
- All translation JSON files parse.

Closes #89
