### PR TITLE
chore(release): bump version to v1.4.0

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
Bump manifest version 1.3.0 -> 1.4.0 ahead of the v1.4.0 stable release (dev -> main).

This dev cycle adds: W4X GATT-cache-clear retry (#73), readable Wh energy sensor + kWh display precision fix (#87), and an instantaneous Power (W) sensor gated on AC power (#89).