### PR TITLE
release: v1.4.0 — Wh energy + Power sensor, W4X GATT-cache retry

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -303,19 +303,7 @@ class PetkitBleClient:
             self._device,
             self._device.address,
         )
-        try:
-            await self._client.start_notify(BLE_NOTIFY_UUID, self._on_notify)
-        except BleakCharacteristicNotFoundError:
-            # Some models (e.g. W4X) don't expose the notify characteristic.
-            # Responses are only delivered via notifications, so we cannot
-            # communicate at all — re-raise so callers can abort/handle
-            # explicitly (config_flow aborts with "unsupported_device").
-            _LOGGER.warning(
-                "Device %s does not expose notify UUID %s; the model is not supported",
-                self._device.address,
-                BLE_NOTIFY_UUID,
-            )
-            raise
+        await self._start_notify_with_cache_retry()
 
         self._rx_buf.clear()
         # Discard any stale notifications from a previous connection
@@ -324,6 +312,63 @@ class PetkitBleClient:
         self._seq = 0
         # Allow device time to settle before sending first command
         await asyncio.sleep(0.5)
+
+    async def _start_notify_with_cache_retry(self) -> None:
+        """Subscribe to notifications, refreshing a stale GATT cache on failure.
+
+        The notify characteristic can be missing from the cached GATT database
+        even when the device does expose it — for example when the device is
+        still bonded to another client (the Petkit app) or when the OS / ESPHome
+        proxy holds a stale cached service table. Research confirms the W4X is
+        part of the W5 family and does expose notify UUID ``0000aaa1``, so a
+        missing characteristic is treated as a possibly-stale cache first: clear
+        the cache, reconnect to force a fresh service discovery, and retry once
+        before reporting the model as unsupported.
+        """
+        try:
+            await self._client.start_notify(BLE_NOTIFY_UUID, self._on_notify)
+            return
+        except BleakCharacteristicNotFoundError:
+            _LOGGER.warning(
+                "Notify UUID %s not found for %s; clearing GATT cache and retrying service discovery",
+                BLE_NOTIFY_UUID,
+                self._device.address,
+            )
+
+        await self._clear_cache_and_reconnect()
+
+        try:
+            await self._client.start_notify(BLE_NOTIFY_UUID, self._on_notify)
+        except BleakCharacteristicNotFoundError:
+            # Responses are only delivered via notifications, so without this
+            # characteristic we cannot communicate at all — re-raise so callers
+            # can abort/handle explicitly (config_flow aborts with
+            # "unsupported_device").
+            _LOGGER.warning(
+                "Device %s still does not expose notify UUID %s after a GATT cache refresh; the model is not supported",
+                self._device.address,
+                BLE_NOTIFY_UUID,
+            )
+            raise
+
+    async def _clear_cache_and_reconnect(self) -> None:
+        """Clear the GATT cache and re-establish the connection to rediscover.
+
+        ``clear_cache`` is not available on every bleak backend / ESPHome-proxy
+        client, so it is guarded; when absent, the disconnect + reconnect alone
+        often refreshes the cached service table.
+        """
+        if self._client is not None:
+            if hasattr(self._client, "clear_cache"):
+                with contextlib.suppress(Exception):
+                    await self._client.clear_cache()
+            with contextlib.suppress(Exception):
+                await self._client.disconnect()
+        self._client = await establish_connection(
+            BleakClient,
+            self._device,
+            self._device.address,
+        )
 
     async def disconnect(self) -> None:
         """Disconnect from the device, suppressing cleanup errors."""

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -172,6 +172,11 @@ class PetkitFountainData:
         coeff = POWER_COEFF_W.get(self.alias, DEFAULT_POWER_COEFF_W)
         return coeff * self.pump_runtime_today / 3600 / 1000
 
+    @property
+    def energy_today_wh(self) -> float:
+        """Estimated energy used today in Wh (readable form of ``energy_today_kwh``)."""
+        return self.energy_today_kwh * 1000
+
 
 class PetkitBleClient:
     """BLE client for Petkit water fountains implementing the Petkit protocol."""

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -147,6 +147,28 @@ class PetkitFountainData:
         return self.running_status == 1
 
     @property
+    def is_on_ac_power(self) -> bool:
+        """Return True when the fountain is powered from AC (mains).
+
+        AC-only models (W4/W5/CTW2) are always mains-powered. Battery-capable
+        models (CTW3) report ``electric_status == 2`` when running on AC.
+        """
+        if not self.is_ctw3:
+            return True
+        return self.electric_status == 2
+
+    @property
+    def power_w(self) -> float:
+        """Instantaneous power draw in watts.
+
+        Only reported while the pump is running and the device is on AC power;
+        on battery (CTW3) or when idle the draw from the mains is 0 W.
+        """
+        if not self.is_pump_running or not self.is_on_ac_power:
+            return 0.0
+        return POWER_COEFF_W.get(self.alias, DEFAULT_POWER_COEFF_W)
+
+    @property
     def filter_days_remaining(self) -> int:
         """Estimate remaining filter life in days."""
         if self.mode == 1:

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfPower,
     UnitOfTime,
     UnitOfVolume,
 )
@@ -90,6 +91,15 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLUME,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda d: round(d.water_purified_today_liters, 3),
+    ),
+    PetkitSensorEntityDescription(
+        key="power",
+        translation_key="power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda d: round(d.power_w, 3),
     ),
     PetkitSensorEntityDescription(
         key="energy_today",

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -97,7 +97,15 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=4,
         value_fn=lambda d: round(d.energy_today_kwh, 6),
+    ),
+    PetkitSensorEntityDescription(
+        key="energy_today_wh",
+        translation_key="energy_today_wh",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        suggested_display_precision=2,
+        value_fn=lambda d: round(d.energy_today_wh, 3),
     ),
     PetkitSensorEntityDescription(
         key="filter_days_remaining",

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Battery Voltage"},
       "water_purified_today": {"name": "Water Purified Today"},
       "energy_today": {"name": "Energy Today"},
+      "power": {"name": "Power"},
       "energy_today_wh": {"name": "Energy Today (Wh)"},
       "filter_days_remaining": {"name": "Filter Days Remaining"},
       "firmware": {"name": "Firmware"},

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Battery Voltage"},
       "water_purified_today": {"name": "Water Purified Today"},
       "energy_today": {"name": "Energy Today"},
+      "energy_today_wh": {"name": "Energy Today (Wh)"},
       "filter_days_remaining": {"name": "Filter Days Remaining"},
       "firmware": {"name": "Firmware"},
       "hardware_version": {"name": "Hardware Version"},

--- a/custom_components/petkit_ble/translations/fr.json
+++ b/custom_components/petkit_ble/translations/fr.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Tension de la batterie"},
       "water_purified_today": {"name": "Eau purifiée aujourd'hui"},
       "energy_today": {"name": "Énergie aujourd'hui"},
+      "energy_today_wh": {"name": "Énergie aujourd'hui (Wh)"},
       "filter_days_remaining": {"name": "Jours restants avant changement du filtre"},
       "firmware": {"name": "Firmware"},
       "hardware_version": {"name": "Version matérielle"},

--- a/custom_components/petkit_ble/translations/fr.json
+++ b/custom_components/petkit_ble/translations/fr.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Tension de la batterie"},
       "water_purified_today": {"name": "Eau purifiée aujourd'hui"},
       "energy_today": {"name": "Énergie aujourd'hui"},
+      "power": {"name": "Puissance"},
       "energy_today_wh": {"name": "Énergie aujourd'hui (Wh)"},
       "filter_days_remaining": {"name": "Jours restants avant changement du filtre"},
       "firmware": {"name": "Firmware"},

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Batterijspanning"},
       "water_purified_today": {"name": "Gezuiverd water vandaag"},
       "energy_today": {"name": "Energieverbruik vandaag"},
+      "power": {"name": "Vermogen"},
       "energy_today_wh": {"name": "Energieverbruik vandaag (Wh)"},
       "filter_days_remaining": {"name": "Resterende filterdagen"},
       "firmware": {"name": "Firmware"},

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Batterijspanning"},
       "water_purified_today": {"name": "Gezuiverd water vandaag"},
       "energy_today": {"name": "Energieverbruik vandaag"},
+      "energy_today_wh": {"name": "Energieverbruik vandaag (Wh)"},
       "filter_days_remaining": {"name": "Resterende filterdagen"},
       "firmware": {"name": "Firmware"},
       "hardware_version": {"name": "Hardwareversie"},

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Напруга батареї"},
       "water_purified_today": {"name": "Очищена вода сьогодні"},
       "energy_today": {"name": "Споживання енергії сьогодні"},
+      "power": {"name": "Потужність"},
       "energy_today_wh": {"name": "Споживання енергії сьогодні (Вт·год)"},
       "filter_days_remaining": {"name": "Залишилось днів фільтра"},
       "firmware": {"name": "Прошивка"},

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -64,6 +64,7 @@
       "battery_voltage_mv": {"name": "Напруга батареї"},
       "water_purified_today": {"name": "Очищена вода сьогодні"},
       "energy_today": {"name": "Споживання енергії сьогодні"},
+      "energy_today_wh": {"name": "Споживання енергії сьогодні (Вт·год)"},
       "filter_days_remaining": {"name": "Залишилось днів фільтра"},
       "firmware": {"name": "Прошивка"},
       "hardware_version": {"name": "Версія апаратного забезпечення"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ _HA_STUBS = [
     "bleak",
     "bleak.backends",
     "bleak.backends.device",
+    "bleak.exc",
     "bleak_retry_connector",
     "voluptuous",
 ]

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -42,6 +42,54 @@ class TestIsPumpRunning:
         assert data.is_pump_running is False
 
 
+class TestIsOnAcPower:
+    """Tests for is_on_ac_power property."""
+
+    def test_ac_only_model_always_on_ac(self) -> None:
+        """AC-only models (non-CTW3) are always mains-powered regardless of electric_status."""
+        data = PetkitFountainData(alias=ALIAS_W5, electric_status=0)
+        assert data.is_on_ac_power is True
+
+    def test_ctw3_on_ac(self) -> None:
+        """CTW3 with electric_status == 2 is on AC."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, electric_status=2)
+        assert data.is_on_ac_power is True
+
+    def test_ctw3_on_battery(self) -> None:
+        """CTW3 with electric_status != 2 is on battery."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, electric_status=1)
+        assert data.is_on_ac_power is False
+
+
+class TestPowerW:
+    """Tests for power_w property."""
+
+    def test_running_on_ac_default(self) -> None:
+        """Pump running on AC → default coefficient (0.75 W)."""
+        data = PetkitFountainData(alias=ALIAS_W5, running_status=1)
+        assert data.power_w == pytest.approx(0.75)
+
+    def test_running_on_ac_w5c(self) -> None:
+        """W5C uses its specific coefficient (0.182 W)."""
+        data = PetkitFountainData(alias=ALIAS_W5C, running_status=1)
+        assert data.power_w == pytest.approx(0.182)
+
+    def test_not_running(self) -> None:
+        """Pump idle → 0 W even on AC."""
+        data = PetkitFountainData(alias=ALIAS_W5, running_status=0)
+        assert data.power_w == 0.0
+
+    def test_ctw3_on_battery(self) -> None:
+        """CTW3 running on battery (electric_status != 2) → 0 W from the mains."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, running_status=1, electric_status=1)
+        assert data.power_w == 0.0
+
+    def test_ctw3_running_on_ac(self) -> None:
+        """CTW3 running on AC → default coefficient."""
+        data = PetkitFountainData(alias=ALIAS_CTW3, running_status=1, electric_status=2)
+        assert data.power_w == pytest.approx(0.75)
+
+
 class TestFilterDaysRemaining:
     """Tests for filter_days_remaining property."""
 


### PR DESCRIPTION
## Release v1.4.0

Promotes the current `dev` cycle to a stable release for all HACS users.

### Highlights
- **W4X support / BLE robustness (#73):** on `BleakCharacteristicNotFoundError`, clear the stale GATT cache, reconnect to force a fresh service discovery, and retry the notify subscription once before reporting the model as unsupported.
- **Energy readability (#87):** add a display-only **Energy Today (Wh)** sensor and set `suggested_display_precision=4` on the kWh sensor so tiny daily values no longer render as `0.00 kWh`.
- **Power sensor (#89):** add an instantaneous **Power (W)** sensor reporting the per-model coefficient while the pump runs and the device is on AC power (0 W on battery/idle).
- **Tests:** unit coverage for `is_on_ac_power` / `power_w`; conftest stubs `bleak.exc` so the suite collects on a plain pytest run.

### Version
`manifest.json` bumped 1.3.0 → 1.4.0.
