### PR TITLE
ci: fix Copilot review workflow on main

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -11,9 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
     steps:
-      - name: Request Copilot code review
-        uses: github/copilot-code-review@v1
+      - name: Request Copilot as reviewer
+        uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: ['Copilot'],
+            });

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -9,6 +9,9 @@ jobs:
   copilot-review:
     name: Request Copilot Code Review
     runs-on: ubuntu-latest
+    # Skip PRs from forks: the pull_request event grants a read-only
+    # GITHUB_TOKEN for forked PRs, so requestReviewers returns 403.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Replace the non-existent \github/copilot-code-review@v1\ action in \.github/workflows/copilot-review.yml\ on \main\ with the working \ctions/github-script@v7\ step that requests the Copilot reviewer (already used on \dev\).

This fixes the failing 'Request Copilot Code Review' check that appears on every PR targeting \main\ (e.g. release PRs #82 and #92). After merge, \main\ and \dev\ match, so future release merges stay clean.

Closes #93