### PR TITLE
ci: sync copilot-review workflow with main (skip forked PRs)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -9,6 +9,9 @@ jobs:
   copilot-review:
     name: Request Copilot Code Review
     runs-on: ubuntu-latest
+    # Skip PRs from forks: the pull_request event grants a read-only
+    # GITHUB_TOKEN for forked PRs, so requestReviewers returns 403.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Keep \dev\ and \main\ identical for \.github/workflows/copilot-review.yml\. Adds the same fork-skip guard merged to \main\ in #94 so future \dev\ -> \main\ releases don't re-diverge on this file.

Refs #93