### PR TITLE
feat: pin stable, language-independent entity IDs for dashboard portability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -133,6 +133,10 @@ kwh = power_w * pump_runtime_min / 60 / 1000
 - **`async_step_bluetooth()`** — triggered automatically by HA when a matching BLE device
   is seen (matchers defined in `manifest.json` under the `bluetooth` key).
 - **`CoordinatorEntity`** — all platform entities inherit from `PetkitBleEntity`.
+- **Stable entity IDs** — `PetkitBleEntity.__init__` pins `entity_id` to
+  `<platform>.<slug(CONF_NAME)>_<key>` via `async_generate_entity_id`, so IDs are
+  language-independent (portable dashboards). Friendly names stay localized via
+  `translation_key`. Each platform passes its `ENTITY_ID_FORMAT` to `super().__init__`.
 
 ---
 
@@ -290,7 +294,7 @@ versions are the right granularity for "shipped to all HACS users".
 - **Linter**: ruff — run `ruff check custom_components/` before committing.
 - **Commit style**: Conventional Commits (`feat:`, `fix:`, `docs:`, `ci:`, `refactor:`).
 - **Translations**: Add keys to `strings.json` first, then mirror to all `translations/*.json`.
-- **New sensors**: Add to `sensor.py` description list + `strings.json` + all translation files.
+- **New sensors**: Add to `sensor.py` description list + `strings.json` + all translation files. The `entity_id` is auto-pinned to `sensor.<device>_<key>`; choose a stable English `key`.
 - **No direct push to `main` or `dev`** — always use a PR.
 
 ---

--- a/.github/instructions/petkit-ble.instructions.md
+++ b/.github/instructions/petkit-ble.instructions.md
@@ -15,6 +15,7 @@ Apply this knowledge when reading, writing, or reviewing code in `custom_compone
 - **Python:** 3.12+, `from __future__ import annotations` in every module, `collections.abc.Callable`
 - **Linter:** ruff — run `uv run ruff check custom_components/` before committing
 - **Language:** ALL code, comments, docstrings, commit messages, PR titles/descriptions, and GitHub issues MUST be written in English. No exceptions, even when the user writes in another language.
+- **Entity IDs:** `PetkitBleEntity.__init__` pins `entity_id` to a stable, language-independent value `<platform>.<slug(CONF_NAME)>_<key>` (via `async_generate_entity_id`), so shared dashboards stay portable across HA UI languages. Friendly names remain localized through `translation_key`. Every platform MUST pass its own `ENTITY_ID_FORMAT` (imported from `homeassistant.components.<platform>`) as the third argument to `super().__init__(...)`.
 - **Branching:** feature/* and fix/* → PR to `dev`; never push directly to `dev` or `main`
 - **PR review gate:** Always wait for the Copilot code reviewer to *actually submit* its review (not just the workflow run to finish) before merging. The review comments arrive asynchronously after the "Request Copilot Code Review" workflow turns green. Verify with `gh pr view <N> --json reviews` and address every comment before merge.
 - **Post-merge:** After merging to `dev`, verify the `Pre-release` workflow produced a new `v<version>-dev.<timestamp>` GitHub release; this is what HACS beta-testers install.
@@ -105,8 +106,11 @@ CTW2   → CTW2
 1. Add field to `PetkitFountainData` in `ble_client.py`
 2. Parse in the correct `_parse_state_*` or `_parse_config_*` method
 3. Add `PetkitSensorEntityDescription` entry to `SENSOR_DESCRIPTIONS` in `sensor.py`
+   (the sensor platform already passes `ENTITY_ID_FORMAT`, so the `entity_id`
+   becomes `sensor.<device>_<key>` automatically — pick a stable English `key`)
 4. Add translation key to `strings.json` (source of truth)
-5. Mirror to `translations/en.json`, `translations/nl.json`, `translations/uk.json`
+5. Mirror to `translations/en.json`, `translations/nl.json`, `translations/fr.json`,
+   `translations/uk.json`
 
 ## File Map
 

--- a/custom_components/petkit_ble/binary_sensor.py
+++ b/custom_components/petkit_ble/binary_sensor.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import (
+    ENTITY_ID_FORMAT,
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -119,7 +120,7 @@ class PetkitBleBinarySensor(PetkitBleEntity, BinarySensorEntity):
         description: PetkitBinarySensorDescription,
     ) -> None:
         """Initialise the binary sensor."""
-        super().__init__(coordinator, description.key)
+        super().__init__(coordinator, description.key, ENTITY_ID_FORMAT)
         self.entity_description = description
 
     @property

--- a/custom_components/petkit_ble/button.py
+++ b/custom_components/petkit_ble/button.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.button import ENTITY_ID_FORMAT, ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -58,7 +58,7 @@ class PetkitBleButton(PetkitBleEntity, ButtonEntity):
         description: PetkitButtonDescription,
     ) -> None:
         """Initialise the button."""
-        super().__init__(coordinator, description.key)
+        super().__init__(coordinator, description.key, ENTITY_ID_FORMAT)
         self.entity_description = description
 
     async def async_press(self) -> None:

--- a/custom_components/petkit_ble/config_flow.py
+++ b/custom_components/petkit_ble/config_flow.py
@@ -126,7 +126,11 @@ class PetkitBleConfigFlow(ConfigFlow, domain=DOMAIN):
         """Scan for nearby Petkit BLE devices and let the user pick one."""
         if user_input is not None:
             address: str = user_input[CONF_ADDRESS].strip().upper()
-            name: str = user_input.get(CONF_NAME, address)
+            # Prefer an explicitly entered name, then the discovered BLE name
+            # (the selector only submits the address), then the MAC as a last
+            # resort. Using the BLE name keeps pinned entity IDs and model
+            # detection based on e.g. "Petkit_CTW3_100" rather than the MAC.
+            name: str = user_input.get(CONF_NAME, "").strip() or self._discovered_devices.get(address, "") or address
 
             await self.async_set_unique_id(address)
             self._abort_if_unique_id_configured()

--- a/custom_components/petkit_ble/entity.py
+++ b/custom_components/petkit_ble/entity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_ADDRESS, CONF_MODEL, CONF_NAME, DOMAIN
@@ -14,13 +15,34 @@ class PetkitBleEntity(CoordinatorEntity[PetkitBleCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: PetkitBleCoordinator, key: str) -> None:
-        """Initialise the entity."""
+    def __init__(
+        self,
+        coordinator: PetkitBleCoordinator,
+        key: str,
+        entity_id_format: str | None = None,
+    ) -> None:
+        """Initialise the entity.
+
+        When ``entity_id_format`` is provided, the ``entity_id`` is pinned to a
+        stable, language-independent value of the form
+        ``<platform>.<slug(device_name)>_<key>`` (e.g.
+        ``sensor.petkit_ctw3_100_filter_percent``). The friendly name shown in
+        the UI is still localized via ``translation_key``; only the entity_id is
+        forced to English so shared dashboards remain portable across languages.
+        """
         super().__init__(coordinator)
         address: str = coordinator.config_entry.data[CONF_ADDRESS]
         mac_normalized = address.replace(":", "").lower()
         self._attr_unique_id = f"{mac_normalized}_{key}"
         self._address = address
+
+        if entity_id_format is not None:
+            device_name: str = coordinator.config_entry.data[CONF_NAME]
+            self.entity_id = async_generate_entity_id(
+                entity_id_format,
+                f"{device_name}_{key}",
+                hass=coordinator.hass,
+            )
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/petkit_ble/number.py
+++ b/custom_components/petkit_ble/number.py
@@ -6,7 +6,12 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from homeassistant.components.number import NumberEntity, NumberEntityDescription, NumberMode
+from homeassistant.components.number import (
+    ENTITY_ID_FORMAT,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -105,7 +110,7 @@ class PetkitBleNumber(PetkitBleEntity, NumberEntity):
         description: PetkitNumberDescription,
     ) -> None:
         """Initialise the number entity."""
-        super().__init__(coordinator, description.key)
+        super().__init__(coordinator, description.key, ENTITY_ID_FORMAT)
         self.entity_description = description
 
     @property

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.components.select import ENTITY_ID_FORMAT, SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -41,7 +41,7 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
 
     def __init__(self, coordinator: PetkitBleCoordinator) -> None:
         """Initialise the mode select."""
-        super().__init__(coordinator, MODE_SELECT_DESCRIPTION.key)
+        super().__init__(coordinator, MODE_SELECT_DESCRIPTION.key, ENTITY_ID_FORMAT)
         self.entity_description = MODE_SELECT_DESCRIPTION
 
     @property

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (
+    ENTITY_ID_FORMAT,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -185,7 +186,7 @@ class PetkitBleSensor(PetkitBleEntity, SensorEntity):
         description: PetkitSensorEntityDescription,
     ) -> None:
         """Initialise the sensor."""
-        super().__init__(coordinator, description.key)
+        super().__init__(coordinator, description.key, ENTITY_ID_FORMAT)
         self.entity_description = description
 
     @property

--- a/custom_components/petkit_ble/switch.py
+++ b/custom_components/petkit_ble/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -43,7 +43,7 @@ class PetkitPowerSwitch(PetkitBleEntity, SwitchEntity):
 
     def __init__(self, coordinator: PetkitBleCoordinator) -> None:
         """Initialise the power switch."""
-        super().__init__(coordinator, POWER_SWITCH_DESCRIPTION.key)
+        super().__init__(coordinator, POWER_SWITCH_DESCRIPTION.key, ENTITY_ID_FORMAT)
         self.entity_description = POWER_SWITCH_DESCRIPTION
 
     @property
@@ -96,7 +96,7 @@ class PetkitSettingsSwitch(PetkitBleEntity, SwitchEntity):
 
     def __init__(self, coordinator: PetkitBleCoordinator, key: str, field_name: str) -> None:
         """Initialise the settings switch."""
-        super().__init__(coordinator, key)
+        super().__init__(coordinator, key, ENTITY_ID_FORMAT)
         self.entity_description = SwitchEntityDescription(key=key, translation_key=key)
         self._field_name = field_name
 

--- a/custom_components/petkit_ble/time.py
+++ b/custom_components/petkit_ble/time.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from homeassistant.components.time import TimeEntity, TimeEntityDescription
+from homeassistant.components.time import ENTITY_ID_FORMAT, TimeEntity, TimeEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -93,7 +93,7 @@ class PetkitBleTime(PetkitBleEntity, TimeEntity):
         description: PetkitTimeDescription,
     ) -> None:
         """Initialise the time entity."""
-        super().__init__(coordinator, description.key)
+        super().__init__(coordinator, description.key, ENTITY_ID_FORMAT)
         self.entity_description = description
 
     @property


### PR DESCRIPTION
Fixes #96.

### What
Pin the `entity_id` in `PetkitBleEntity` to a stable, language-independent value with structure `[platform].[device_slug]_[key]` (e.g. `binary_sensor.petkit_ctw3_100_warning_breakdown`, `sensor.petkit_ctw3_100_filter_percent`), while keeping friendly names localized via `translation_key`.

### Why
Entity IDs were previously derived from the localized entity name at creation, so a Dutch HA produced `..._hardwarestoring` and other languages differed. A shared dashboard YAML that references entity IDs broke across languages.

### How
- `entity.py`: base `__init__` takes an `entity_id_format` argument and pins `self.entity_id` via `async_generate_entity_id(fmt, f"{CONF_NAME}_{key}", hass=coordinator.hass)`. The device slug comes from the language-independent `CONF_NAME` (BLE name); the suffix is the stable English entity `key`.
- Each platform (sensor, binary_sensor, button, number, select, switch, time) imports its own `ENTITY_ID_FORMAT` and passes it to `super().__init__`.
- Translation files unchanged — localized friendly names stay intact (HA best practice).
- Docs updated (`copilot-instructions.md`, `petkit-ble.instructions.md`).

### Migration note
Existing entities keep their current IDs (Home Assistant does not auto-rename). To adopt the new IDs, remove and re-add the device once, or rename entities manually. New installations get the English key-based IDs directly.

### Validation
- `ruff check` + `ruff format --check`: pass
- Test suite: 109 passed
