### PR TITLE
docs(entity): clarify entity_id is language-independent

### DIFF
--- a/custom_components/petkit_ble/entity.py
+++ b/custom_components/petkit_ble/entity.py
@@ -28,9 +28,9 @@ class PetkitBleEntity(CoordinatorEntity[PetkitBleCoordinator]):
         ``<platform>.<slug(device_name)>_<key>`` (e.g.
         ``sensor.petkit_ctw3_100_filter_percent``). The friendly name shown in
         the UI is still localized via ``translation_key``; only the entity_id is
-        kept language-independent (derived from the BLE device name and the
-        English entity key) so shared dashboards remain portable across
-        languages.
+        kept language-independent (derived from the configured device name,
+        typically the BLE advertisement name, and the English entity key) so
+        shared dashboards remain portable across languages.
         """
         super().__init__(coordinator)
         address: str = coordinator.config_entry.data[CONF_ADDRESS]

--- a/custom_components/petkit_ble/entity.py
+++ b/custom_components/petkit_ble/entity.py
@@ -28,7 +28,9 @@ class PetkitBleEntity(CoordinatorEntity[PetkitBleCoordinator]):
         ``<platform>.<slug(device_name)>_<key>`` (e.g.
         ``sensor.petkit_ctw3_100_filter_percent``). The friendly name shown in
         the UI is still localized via ``translation_key``; only the entity_id is
-        forced to English so shared dashboards remain portable across languages.
+        kept language-independent (derived from the BLE device name and the
+        English entity key) so shared dashboards remain portable across
+        languages.
         """
         super().__init__(coordinator)
         address: str = coordinator.config_entry.data[CONF_ADDRESS]


### PR DESCRIPTION
Addresses a Copilot review comment on #99: the base entity docstring said the entity_id is 'forced to English', but it is derived from the BLE device name plus the English entity key, so it is language-independent rather than strictly English. Docstring-only change.