### PR TITLE
fix: open debug log file off the event loop

### DIFF
--- a/custom_components/petkit_ble/__init__.py
+++ b/custom_components/petkit_ble/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from logging.handlers import RotatingFileHandler
@@ -30,43 +31,62 @@ _INTEGRATION_LOGGER = logging.getLogger(f"custom_components.{DOMAIN}")
 # Track which config entries have debug enabled and a shared file handler.
 _debug_entries: set[str] = set()
 _file_handler: logging.Handler | None = None
+# Serialise handler creation/teardown: ``_apply_debug_option`` is now async and
+# has an ``await`` point (the executor job), so concurrent calls for multiple
+# entries must not race on ``_file_handler``.
+_debug_lock = asyncio.Lock()
 
 
-def _apply_debug_option(hass: HomeAssistant, entry: ConfigEntry) -> None:
+def _build_file_handler(log_path: str) -> RotatingFileHandler:
+    """Build the rotating file handler.
+
+    ``RotatingFileHandler`` opens the log file in its constructor, which is
+    blocking file I/O; this helper is always run in an executor so the open
+    never happens on the event loop.
+    """
+    handler = RotatingFileHandler(log_path, maxBytes=5 * 1024 * 1024, backupCount=2, encoding="utf-8")
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+    )
+    return handler
+
+
+async def _apply_debug_option(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Apply the debug option: set log level and manage the petkit.log file handler."""
     global _file_handler
 
     debug = entry.options.get(CONF_DEBUG, False)
 
-    if debug:
-        _debug_entries.add(entry.entry_id)
-    else:
-        _debug_entries.discard(entry.entry_id)
+    async with _debug_lock:
+        if debug:
+            _debug_entries.add(entry.entry_id)
+        else:
+            _debug_entries.discard(entry.entry_id)
 
-    # Log level follows the union of all entries: DEBUG if any entry has it on.
-    _INTEGRATION_LOGGER.setLevel(logging.DEBUG if _debug_entries else logging.NOTSET)
+        # Log level follows the union of all entries: DEBUG if any entry has it on.
+        _INTEGRATION_LOGGER.setLevel(logging.DEBUG if _debug_entries else logging.NOTSET)
 
-    if _debug_entries and _file_handler is None:
-        log_path = os.path.join(hass.config.config_dir, "petkit.log")
-        handler = RotatingFileHandler(log_path, maxBytes=5 * 1024 * 1024, backupCount=2, encoding="utf-8")
-        handler.setLevel(logging.DEBUG)
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-        )
-        _INTEGRATION_LOGGER.addHandler(handler)
-        _file_handler = handler
-        _LOGGER.debug("Debug log file opened: %s", log_path)
+        if _debug_entries and _file_handler is None:
+            log_path = os.path.join(hass.config.config_dir, "petkit.log")
+            # Open the log file off the event loop to avoid a blocking open().
+            handler = await hass.async_add_executor_job(_build_file_handler, log_path)
+            _INTEGRATION_LOGGER.addHandler(handler)
+            _file_handler = handler
+            _LOGGER.debug("Debug log file opened: %s", log_path)
 
-    elif not _debug_entries and _file_handler is not None:
-        _INTEGRATION_LOGGER.removeHandler(_file_handler)
-        _file_handler.close()
-        _file_handler = None
-        _LOGGER.info("Debug log file closed")
+        elif not _debug_entries and _file_handler is not None:
+            handler = _file_handler
+            _INTEGRATION_LOGGER.removeHandler(handler)
+            _file_handler = None
+            # Closing flushes and closes the file — also blocking I/O.
+            await hass.async_add_executor_job(handler.close)
+            _LOGGER.info("Debug log file closed")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Petkit BLE from a config entry."""
-    _apply_debug_option(hass, entry)
+    await _apply_debug_option(hass, entry)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     coordinator = PetkitBleCoordinator(hass, entry)
@@ -79,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update — re-apply debug level without full reload."""
-    _apply_debug_option(hass, entry)
+    await _apply_debug_option(hass, entry)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -87,5 +107,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Clean up debug tracking for this entry so the file handler is removed
     # if no other entry still has debug enabled.
     _debug_entries.discard(entry.entry_id)
-    _apply_debug_option(hass, entry)
+    await _apply_debug_option(hass, entry)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/petkit_ble/__init__.py
+++ b/custom_components/petkit_ble/__init__.py
@@ -52,11 +52,16 @@ def _build_file_handler(log_path: str) -> RotatingFileHandler:
     return handler
 
 
-async def _apply_debug_option(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Apply the debug option: set log level and manage the petkit.log file handler."""
+async def _apply_debug_option(hass: HomeAssistant, entry: ConfigEntry, *, unloading: bool = False) -> None:
+    """Apply the debug option: set log level and manage the petkit.log file handler.
+
+    When ``unloading`` is ``True`` the entry is always treated as debug-off so
+    it is removed from the active set (used from ``async_unload_entry``),
+    regardless of its stored ``CONF_DEBUG`` option.
+    """
     global _file_handler
 
-    debug = entry.options.get(CONF_DEBUG, False)
+    debug = entry.options.get(CONF_DEBUG, False) and not unloading
 
     async with _debug_lock:
         if debug:
@@ -105,7 +110,8 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a Petkit BLE config entry."""
     # Clean up debug tracking for this entry so the file handler is removed
-    # if no other entry still has debug enabled.
-    _debug_entries.discard(entry.entry_id)
-    await _apply_debug_option(hass, entry)
+    # if no other entry still has debug enabled. Pass ``unloading`` so the
+    # discard happens inside the lock and the entry is not re-added from its
+    # stored options.
+    await _apply_debug_option(hass, entry, unloading=True)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)


### PR DESCRIPTION
## Summary

Fixes #101 — a blocking `open()` inside the Home Assistant event loop when debug logging is enabled.

`RotatingFileHandler` opens the log file in its constructor (blocking file I/O), and it was created synchronously in `async_setup_entry` via `_apply_debug_option`, so HA logged:

```
Detected blocking call to open with args ('/config/petkit.log', 'a') inside the event loop
by custom integration 'petkit_ble' at custom_components/petkit_ble/__init__.py, line 51
```

Reported by @Benjamin45590 in #73 (unrelated to that issue's root cause, a faulty BT adapter).

## Changes

- `_apply_debug_option` is now `async`.
- The `RotatingFileHandler` is built in `hass.async_add_executor_job(_build_file_handler, ...)`, so the file open happens off the event loop.
- Handler `close()` (also blocking I/O) runs in an executor too.
- Added a module-level `asyncio.Lock` to serialise handler creation/teardown, since the function now has an `await` point and can be called concurrently for multiple entries.
- All three call sites (`async_setup_entry`, `_async_update_listener`, `async_unload_entry`) now `await` it.

## Validation

- `ruff check` + `ruff format --check` — clean.
- `pytest` — 109 passed.
