### PR TITLE
chore(release): bump version to v1.6.0

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
Bump `manifest.json` to `1.6.0` ahead of the `dev` -> `main` stable release. Includes the non-blocking debug-log fix (#101 / #102).