### PR TITLE
fix(ble_client): latch last-valid mode for generic devices when powered off

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -522,7 +522,19 @@ class PetkitBleClient:
             return
         data.raw_state = bytes(payload)
         data.power_status = payload[0]
-        data.mode = payload[1]
+        # When the device is powered off it reports mode=0, which has no entry
+        # in the mode map and would cause the select entity to show "Unknown".
+        # Only update mode when the raw value is a known mode (1=normal, 2=smart).
+        # This mirrors the latch behaviour in _parse_state_ctw3 (issue #57 / #106).
+        mode_raw = payload[1]
+        if mode_raw in (1, 2):
+            data.mode = mode_raw
+        else:
+            _LOGGER.debug(
+                "Generic device reported mode=%d; keeping latched mode=%d",
+                mode_raw,
+                data.mode,
+            )
         data.dnd_state = payload[2]
         data.warning_breakdown = payload[3]
         data.warning_water_missing = payload[4]


### PR DESCRIPTION
## Summary

Fixes #106

When a W4/W5/CTW2/W4X device is powered off, CMD 210 returns payload[1]=0. This value has no entry in the mode map (1=normal, 2=smart), causing the mode select entity to return None and display unknown in the UI.

## Root cause

_parse_state_generic unconditionally wrote payload[1] into data.mode. When the device is off, that byte is 0, and _INT_TO_MODE.get(0) returns None causing the select entity to show unknown state.

Confirmed from the user logs: RX CMD 210 payload[0]=0x00 (power=off), payload[1]=0x00 (mode=0). Coordinator logs: power=0 mode=0 firmware=47 on every poll.

## Fix

In _parse_state_generic, only update data.mode when the raw value is a known mode (1 or 2). When the device reports mode=0 (off/standby), preserve the previously stored mode so the select entity retains the last-known operating mode.

This mirrors the existing latch behaviour in _parse_state_ctw3 added for the same reason (issue #57).

## Files changed

- custom_components/petkit_ble/ble_client.py: _parse_state_generic latch mode + debug log
