### PR TITLE
fix: preserve W4X mode across polls

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -59,7 +59,7 @@ class PetkitFountainData:
 
     # Power & mode (CMD 210)
     power_status: int = 0  # 0=off, 1=on
-    mode: int = 1  # 1=normal, 2=smart
+    mode: int = 0  # 0=unknown/off, 1=normal, 2=smart
     running_status: int = 0
     dnd_state: int = 0
 
@@ -171,7 +171,7 @@ class PetkitFountainData:
     @property
     def filter_days_remaining(self) -> int:
         """Estimate remaining filter life in days."""
-        if self.mode == 1:
+        if self.mode in (0, 1):
             # Normal mode: pump runs continuously, filter lasts 60 days at 100%
             return math.ceil(self.filter_percent / 100 * FILTER_LIFE_NORMAL_DAYS)
 
@@ -632,12 +632,20 @@ class PetkitBleClient:
     # Public API
     # ------------------------------------------------------------------
 
-    async def async_poll(self, alias: str, secret: bytes | None = None) -> PetkitFountainData:
+    async def async_poll(
+        self,
+        alias: str,
+        secret: bytes | None = None,
+        *,
+        initial_mode: int | None = None,
+    ) -> PetkitFountainData:
         """Connect, authenticate, poll all state commands, disconnect.
 
         Returns a fully-populated PetkitFountainData instance.
         """
         data = PetkitFountainData(alias=alias)
+        if initial_mode in (1, 2):
+            data.mode = initial_mode
         try:
             await self._connect()
             await self._authenticate(alias, secret)

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -29,7 +29,17 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from .ble_client import PetkitBleClient, PetkitFountainData
-from .const import CONF_ADDRESS, CONF_DEVICE_SECRET, CONF_MODEL, CONF_NAME, DOMAIN, KNOWN_ALIASES, POLL_INTERVAL
+from .const import (
+    CONF_ADDRESS,
+    CONF_DEVICE_SECRET,
+    CONF_MODEL,
+    CONF_NAME,
+    DOMAIN,
+    KNOWN_ALIASES,
+    MODE_NORMAL,
+    MODE_SMART,
+    POLL_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -98,6 +108,22 @@ def _reconcile_settings_into(
         )
         return True
     return warned
+
+
+def _reconcile_mode_into(data: PetkitFountainData, cached_mode: int | None) -> int | None:
+    """Keep the last known mode when the device reports an unknown value.
+
+    Generic W4/W5/CTW2 devices and CTW3 can both report ``0`` while the pump
+    is off or sleeping. Because the mode select only knows about Normal/Smart,
+    we preserve the last known valid mode across polls instead of letting the
+    UI fall back to ``unknown`` or the dataclass default.
+    """
+    if data.mode in (MODE_NORMAL, MODE_SMART):
+        return data.mode
+    if cached_mode in (MODE_NORMAL, MODE_SMART):
+        data.mode = cached_mode
+        return cached_mode
+    return None
 
 
 # Byte indices in the CMD 210 payload that are known to change every poll
@@ -255,6 +281,10 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         self._settings_cache: dict[str, int] = {}
         self._warned_no_config: bool = False
 
+        # Cache the last valid mode so a device reporting mode=0 while off or
+        # sleeping does not make the HA select flicker back to unknown/normal.
+        self._mode_cache: int | None = None
+
         # Previous CMD 210 raw payload, kept so we can log a byte-by-byte
         # diff between consecutive polls (see _diff_state_bytes). Used as a
         # diagnostic aid for issue #65 (CTW3 detect_status offset unknown).
@@ -406,7 +436,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             if client is None:
                 raise UpdateFailed(f"Petkit fountain {self._name} ({self._address}) not reachable via Bluetooth")
             try:
-                data = await client.async_poll(self._alias, self._secret)
+                data = await client.async_poll(self._alias, self._secret, initial_mode=self._mode_cache)
             except Exception as exc:
                 raise UpdateFailed(f"Error communicating with {self._name}: {exc}") from exc
 
@@ -436,6 +466,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             self._prev_raw_state = data.raw_state
 
         self._reconcile_settings(data)
+        self._mode_cache = _reconcile_mode_into(data, self._mode_cache)
 
         # Self-heal persistence: if the BLE client inferred a corrected alias
         # from the CMD 210 payload (e.g. when the original entry stored a MAC
@@ -522,4 +553,15 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         if self.data is not None:
             setattr(self.data, field, value)
             self.data.config_loaded = True
+            self.async_set_updated_data(self.data)
+
+    @callback
+    def apply_mode_optimistic(self, mode: int) -> None:
+        """Persist a user-selected mode into the live data and cache."""
+        if mode not in (MODE_NORMAL, MODE_SMART):
+            _LOGGER.debug("apply_mode_optimistic: invalid mode %r ignored", mode)
+            return
+        self._mode_cache = mode
+        if self.data is not None:
+            self.data.mode = mode
             self.async_set_updated_data(self.data)

--- a/custom_components/petkit_ble/select.py
+++ b/custom_components/petkit_ble/select.py
@@ -86,6 +86,7 @@ class PetkitModeSelect(PetkitBleEntity, SelectEntity):
         )
         success = await self.coordinator.async_send_command(CMD_SET_POWER_MODE, payload)
         if success:
+            self.coordinator.apply_mode_optimistic(mode_int)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.error("Failed to set mode to %s", option)

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -42,6 +42,14 @@ class TestIsPumpRunning:
         assert data.is_pump_running is False
 
 
+class TestModeDefault:
+    """Tests for the default mode value."""
+
+    def test_default_is_unknown(self) -> None:
+        data = PetkitFountainData()
+        assert data.mode == 0
+
+
 class TestIsOnAcPower:
     """Tests for is_on_ac_power property."""
 
@@ -92,6 +100,12 @@ class TestPowerW:
 
 class TestFilterDaysRemaining:
     """Tests for filter_days_remaining property."""
+
+    def test_unknown_mode_uses_normal_calculation(self) -> None:
+        """Raw mode 0 is treated like Normal for filter-life estimates."""
+        data = PetkitFountainData(mode=0, filter_percent=80)
+        expected = math.ceil(80 / 100 * 60)
+        assert data.filter_days_remaining == expected
 
     def test_normal_mode_full(self) -> None:
         """100% filter in normal mode → ceil(1.0 * 60) = 60 days."""

--- a/tests/test_settings_optimistic.py
+++ b/tests/test_settings_optimistic.py
@@ -24,6 +24,7 @@ from custom_components.petkit_ble.ble_client import (
 from custom_components.petkit_ble.const import ALIAS_CTW3
 from custom_components.petkit_ble.coordinator import (
     _SETTINGS_FIELDS,
+    _reconcile_mode_into,
     _reconcile_settings_into,
 )
 
@@ -144,3 +145,31 @@ class TestReconcileSettingsInto:
         _reconcile_settings_into(fresh, cache, warned=False, name="x", address="y")
         assert fresh.led_switch == 1
         assert fresh.config_loaded is True
+
+
+class TestReconcileModeInto:
+    """The coordinator preserves the last known mode across raw 0 polls."""
+
+    def test_cached_mode_restores_unknown_poll(self) -> None:
+        data = PetkitFountainData(mode=0)
+
+        cached = _reconcile_mode_into(data, 2)
+
+        assert data.mode == 2
+        assert cached == 2
+
+    def test_known_mode_updates_cache(self) -> None:
+        data = PetkitFountainData(mode=2)
+
+        cached = _reconcile_mode_into(data, None)
+
+        assert data.mode == 2
+        assert cached == 2
+
+    def test_unknown_without_cache_stays_unknown(self) -> None:
+        data = PetkitFountainData(mode=0)
+
+        cached = _reconcile_mode_into(data, None)
+
+        assert data.mode == 0
+        assert cached is None


### PR DESCRIPTION
Fixes issue #106.

- Preserve the last valid mode when W4X reports raw mode=0 while off/sleeping.
- Optimistically update the mode after a successful user selection.
- Add regression tests for the mode cache and default mode handling.