### PR TITLE
chore: bump version to v1.7.0

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",


### PR DESCRIPTION
Bumps the integration version to v1.7.0 ahead of the stable release.

Contributor note: thanks to @Benjamin45590 for reporting and testing issue #106, which led to the W4X mode persistence fix included in this release.