### PR TITLE
fix: report command timeout as failure

### DIFF
--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -729,12 +729,14 @@ class PetkitBleClient:
     ) -> bool:
         """Connect, authenticate, send a single command, disconnect.
 
-        Returns True on success.
+        Returns True only when a matching response is received.
         """
         try:
             await self._connect()
             await self._authenticate(alias, secret)
-            await self._send_and_wait(cmd, FRAME_TYPE_SEND, data)
+            response = await self._send_and_wait(cmd, FRAME_TYPE_SEND, data)
+            if response is None:
+                return False
         except Exception:
             _LOGGER.exception("Error sending CMD %d", cmd)
             return False

--- a/tests/test_command_result.py
+++ b/tests/test_command_result.py
@@ -1,0 +1,51 @@
+"""Tests for command success/failure reporting."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.petkit_ble.ble_client import PetkitBleClient
+from custom_components.petkit_ble.const import ALIAS_W5, CMD_SET_POWER_MODE
+
+
+def _run_send_command(response: bytes | None) -> tuple[bool, AsyncMock]:
+    """Run a command with BLE transport methods mocked out."""
+    device = MagicMock()
+    device.address = "AA:BB:CC:DD:EE:FF"
+    client = PetkitBleClient(device)
+    disconnect = AsyncMock()
+
+    with (
+        patch.object(client, "_connect", new=AsyncMock()),
+        patch.object(client, "_authenticate", new=AsyncMock()),
+        patch.object(client, "_send_and_wait", new=AsyncMock(return_value=response)),
+        patch.object(client, "disconnect", new=disconnect),
+    ):
+        result = asyncio.run(client.async_send_command(CMD_SET_POWER_MODE, [1, 0], ALIAS_W5))
+
+    return result, disconnect
+
+
+def test_command_timeout_returns_false() -> None:
+    """A command with no matching response must not be reported as successful."""
+    result, disconnect = _run_send_command(None)
+
+    assert result is False
+    disconnect.assert_awaited_once()
+
+
+def test_command_response_returns_true() -> None:
+    """A received response continues to report command success."""
+    result, disconnect = _run_send_command(b"\x01")
+
+    assert result is True
+    disconnect.assert_awaited_once()
+
+
+def test_empty_response_payload_is_still_a_response() -> None:
+    """An empty payload is distinct from a timeout and remains successful."""
+    result, disconnect = _run_send_command(b"")
+
+    assert result is True
+    disconnect.assert_awaited_once()


### PR DESCRIPTION
Fixes #116

## Summary

`PetkitBleClient.async_send_command()` currently reports success even when `_send_and_wait()` times out and returns `None`.

This change makes command result reporting reflect whether a matching BLE response was actually received.

## Changes

- Capture the result returned by `_send_and_wait()`.
- Return `False` when no matching response is received before timeout.
- Continue treating an empty response payload (`b""`) as a received response rather than a timeout.
- Add regression tests covering:
  - timeout / no response → `False`
  - normal response → `True`
  - empty response payload → `True`
  - disconnect still occurs in all cases

## Scope

This intentionally does not add command-specific ACK payload validation. It only fixes the existing false-success case where no response is received at all.

## Validation

Focused regression tests are included with the change. CI can validate lint, formatting, and repository checks.