### PR TITLE
fix(entities): filter unsupported entities per device model

### DIFF
--- a/custom_components/petkit_ble/binary_sensor.py
+++ b/custom_components/petkit_ble/binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .ble_client import PetkitFountainData
+from .const import CONF_MODEL
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
 
@@ -28,6 +29,7 @@ class PetkitBinarySensorDescription(BinarySensorEntityDescription):
     """Binary sensor description with value and availability callables."""
 
     value_fn: Callable[[PetkitFountainData], bool]
+    supported_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     available_fn: Callable[[PetkitFountainData], bool] = lambda _: True
 
 
@@ -66,6 +68,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PetkitBinarySensorDescription, ...] = (
         translation_key="pet_detected",
         device_class=BinarySensorDeviceClass.OCCUPANCY,
         value_fn=lambda d: bool(d.detect_status),
+        supported_fn=lambda d: d.is_ctw3,
         available_fn=lambda d: d.is_ctw3,
     ),
     PetkitBinarySensorDescription(
@@ -74,6 +77,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PetkitBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PLUG,
         # electric_status == 2 means AC power
         value_fn=lambda d: d.electric_status == 2,
+        supported_fn=lambda d: d.has_battery,
         available_fn=lambda d: d.is_ctw3,
     ),
     PetkitBinarySensorDescription(
@@ -81,6 +85,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PetkitBinarySensorDescription, ...] = (
         translation_key="low_battery",
         device_class=BinarySensorDeviceClass.BATTERY,
         value_fn=lambda d: bool(d.low_battery),
+        supported_fn=lambda d: d.has_battery,
         available_fn=lambda d: d.is_ctw3,
     ),
     PetkitBinarySensorDescription(
@@ -88,13 +93,15 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PetkitBinarySensorDescription, ...] = (
         translation_key="suspended",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda d: not bool(d.suspend_status),
+        supported_fn=lambda d: d.is_ctw3,
         available_fn=lambda d: d.is_ctw3,
     ),
     PetkitBinarySensorDescription(
         key="uvc_active",
         translation_key="uvc_active",
         value_fn=lambda d: bool(d.module_status & 0x01),
-        available_fn=lambda d: d.is_ctw3,
+        supported_fn=lambda d: d.has_uvc,
+        available_fn=lambda d: d.is_ctw3 or d.has_uvc,
     ),
 )
 
@@ -106,7 +113,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up Petkit BLE binary sensors from a config entry."""
     coordinator: PetkitBleCoordinator = config_entry.runtime_data
-    async_add_entities(PetkitBleBinarySensor(coordinator, description) for description in BINARY_SENSOR_DESCRIPTIONS)
+    data = coordinator.data or PetkitFountainData(alias=config_entry.data.get(CONF_MODEL, ""))
+    async_add_entities(
+        PetkitBleBinarySensor(coordinator, description)
+        for description in BINARY_SENSOR_DESCRIPTIONS
+        if description.supported_fn(data)
+    )
 
 
 class PetkitBleBinarySensor(PetkitBleEntity, BinarySensorEntity):

--- a/custom_components/petkit_ble/binary_sensor.py
+++ b/custom_components/petkit_ble/binary_sensor.py
@@ -100,8 +100,8 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PetkitBinarySensorDescription, ...] = (
         key="uvc_active",
         translation_key="uvc_active",
         value_fn=lambda d: bool(d.module_status & 0x01),
-        supported_fn=lambda d: d.has_uvc,
-        available_fn=lambda d: d.is_ctw3 or d.has_uvc,
+        supported_fn=lambda d: d.is_ctw3,
+        available_fn=lambda d: d.is_ctw3,
     ),
 )
 

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -16,7 +16,6 @@ from bleak_retry_connector import establish_connection
 
 from .const import (
     ALIAS_CTW3,
-    ALIAS_W4XUVC,
     AUTH_STEP_DELAY,
     BLE_NOTIFY_UUID,
     BLE_WRITE_UUID,
@@ -150,7 +149,7 @@ class PetkitFountainData:
     @property
     def has_uvc(self) -> bool:
         """Return True if device features UV-C sterilization."""
-        return self.is_ctw3 or self.alias == ALIAS_W4XUVC
+        return self.is_ctw3
 
     @property
     def is_pump_running(self) -> bool:

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -16,6 +16,7 @@ from bleak_retry_connector import establish_connection
 
 from .const import (
     ALIAS_CTW3,
+    ALIAS_W4XUVC,
     AUTH_STEP_DELAY,
     BLE_NOTIFY_UUID,
     BLE_WRITE_UUID,
@@ -140,6 +141,16 @@ class PetkitFountainData:
     def is_ctw3(self) -> bool:
         """Return True if device uses the CTW3 extended state format."""
         return self.alias in CTW3_ALIASES
+
+    @property
+    def has_battery(self) -> bool:
+        """Return True if device supports battery operation."""
+        return self.is_ctw3
+
+    @property
+    def has_uvc(self) -> bool:
+        """Return True if device features UV-C sterilization."""
+        return self.is_ctw3 or self.alias == ALIAS_W4XUVC
 
     @property
     def is_pump_running(self) -> bool:

--- a/custom_components/petkit_ble/number.py
+++ b/custom_components/petkit_ble/number.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .ble_client import PetkitFountainData
-from .const import CMD_WRITE_SETTINGS
+from .const import CMD_WRITE_SETTINGS, CONF_MODEL
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
 from .protocol import build_full_settings_payload
@@ -29,6 +29,7 @@ class PetkitNumberDescription(NumberEntityDescription):
     """Number description with value extractor and setter field name."""
 
     value_fn: Callable[[PetkitFountainData], float | None]
+    supported_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     available_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     field_name: str
 
@@ -72,6 +73,7 @@ NUMBER_DESCRIPTIONS: tuple[PetkitNumberDescription, ...] = (
         native_step=1,
         mode=NumberMode.BOX,
         value_fn=lambda d: d.battery_work_time,
+        supported_fn=lambda d: d.has_battery,
         available_fn=lambda d: d.is_ctw3,
         field_name="battery_work_time",
     ),
@@ -83,6 +85,7 @@ NUMBER_DESCRIPTIONS: tuple[PetkitNumberDescription, ...] = (
         native_step=1,
         mode=NumberMode.BOX,
         value_fn=lambda d: d.battery_sleep_time,
+        supported_fn=lambda d: d.has_battery,
         available_fn=lambda d: d.is_ctw3,
         field_name="battery_sleep_time",
     ),
@@ -96,7 +99,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up Petkit BLE number entities from a config entry."""
     coordinator: PetkitBleCoordinator = config_entry.runtime_data
-    async_add_entities(PetkitBleNumber(coordinator, desc) for desc in NUMBER_DESCRIPTIONS)
+    data = coordinator.data or PetkitFountainData(alias=config_entry.data.get(CONF_MODEL, ""))
+    async_add_entities(PetkitBleNumber(coordinator, desc) for desc in NUMBER_DESCRIPTIONS if desc.supported_fn(data))
 
 
 class PetkitBleNumber(PetkitBleEntity, NumberEntity):

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .ble_client import PetkitFountainData
+from .const import CONF_MODEL
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
 
@@ -38,6 +39,7 @@ class PetkitSensorEntityDescription(SensorEntityDescription):
     """Sensor description with value extractor and optional availability check."""
 
     value_fn: Callable[[PetkitFountainData], float | int | str | None]
+    supported_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     available_fn: Callable[[PetkitFountainData], bool] = lambda _: True
 
 
@@ -74,6 +76,7 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda d: d.battery_percent,
+        supported_fn=lambda d: d.has_battery,
         available_fn=lambda d: d.is_ctw3,
     ),
     PetkitSensorEntityDescription(
@@ -83,6 +86,7 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda d: d.battery_voltage_mv,
+        supported_fn=lambda d: d.has_battery,
         available_fn=lambda d: d.is_ctw3,
     ),
     PetkitSensorEntityDescription(
@@ -152,6 +156,7 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         translation_key="drink_count",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda d: d.drink_event_count,
+        supported_fn=lambda d: d.is_ctw3,
         available_fn=lambda d: d.is_ctw3,
     ),
     PetkitSensorEntityDescription(
@@ -160,6 +165,7 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         value_fn=lambda d: d.state_tail.hex() if d.state_tail else None,
+        supported_fn=lambda d: d.is_ctw3,
         available_fn=lambda d: d.is_ctw3 and bool(d.state_tail),
     ),
 )
@@ -172,7 +178,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up Petkit BLE sensors from a config entry."""
     coordinator: PetkitBleCoordinator = config_entry.runtime_data
-    async_add_entities(PetkitBleSensor(coordinator, description) for description in SENSOR_DESCRIPTIONS)
+    data = coordinator.data or PetkitFountainData(alias=config_entry.data.get(CONF_MODEL, ""))
+    async_add_entities(
+        PetkitBleSensor(coordinator, description)
+        for description in SENSOR_DESCRIPTIONS
+        if description.supported_fn(data)
+    )
 
 
 class PetkitBleSensor(PetkitBleEntity, SensorEntity):

--- a/custom_components/petkit_ble/time.py
+++ b/custom_components/petkit_ble/time.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .ble_client import PetkitFountainData
-from .const import CMD_WRITE_SETTINGS, CTW3_ALIASES
+from .const import CMD_WRITE_SETTINGS, CONF_MODEL, CTW3_ALIASES
 from .coordinator import PetkitBleCoordinator
 from .entity import PetkitBleEntity
 from .protocol import build_full_settings_payload
@@ -37,6 +37,7 @@ class PetkitTimeDescription(TimeEntityDescription):
 
     value_fn: Callable[[PetkitFountainData], int]
     field_name: str
+    supported_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     available_fn: Callable[[PetkitFountainData], bool] = lambda _: True
 
 
@@ -46,6 +47,7 @@ TIME_DESCRIPTIONS: tuple[PetkitTimeDescription, ...] = (
         translation_key="led_on_time",
         value_fn=lambda d: d.led_on_minutes,
         field_name="led_on_minutes",
+        supported_fn=lambda d: not d.is_ctw3,
         available_fn=lambda d: d.alias not in CTW3_ALIASES,
     ),
     PetkitTimeDescription(
@@ -53,6 +55,7 @@ TIME_DESCRIPTIONS: tuple[PetkitTimeDescription, ...] = (
         translation_key="led_off_time",
         value_fn=lambda d: d.led_off_minutes,
         field_name="led_off_minutes",
+        supported_fn=lambda d: not d.is_ctw3,
         available_fn=lambda d: d.alias not in CTW3_ALIASES,
     ),
     PetkitTimeDescription(
@@ -60,6 +63,7 @@ TIME_DESCRIPTIONS: tuple[PetkitTimeDescription, ...] = (
         translation_key="dnd_start_time",
         value_fn=lambda d: d.dnd_start_minutes,
         field_name="dnd_start_minutes",
+        supported_fn=lambda d: not d.is_ctw3,
         available_fn=lambda d: d.alias not in CTW3_ALIASES,
     ),
     PetkitTimeDescription(
@@ -67,6 +71,7 @@ TIME_DESCRIPTIONS: tuple[PetkitTimeDescription, ...] = (
         translation_key="dnd_end_time",
         value_fn=lambda d: d.dnd_end_minutes,
         field_name="dnd_end_minutes",
+        supported_fn=lambda d: not d.is_ctw3,
         available_fn=lambda d: d.alias not in CTW3_ALIASES,
     ),
 )
@@ -79,7 +84,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up Petkit BLE time entities from a config entry."""
     coordinator: PetkitBleCoordinator = config_entry.runtime_data
-    async_add_entities(PetkitBleTime(coordinator, desc) for desc in TIME_DESCRIPTIONS)
+    data = coordinator.data or PetkitFountainData(alias=config_entry.data.get(CONF_MODEL, ""))
+    async_add_entities(PetkitBleTime(coordinator, desc) for desc in TIME_DESCRIPTIONS if desc.supported_fn(data))
 
 
 class PetkitBleTime(PetkitBleEntity, TimeEntity):

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,29 @@
+# Plan: Clean unsupported entities for W4X and other models (Issue #118)
+
+## Context
+Issue #118 reports that several entities are created for W4X devices that are not supported by the hardware (e.g. battery sensors, pet detection, UVC, suspended status, state tail). Because they are instantiated during `async_setup_entry`, Home Assistant registers them and displays them as permanently `Unavailable`.
+
+## Proposed Changes
+
+### 1. Add `supported_fn` to Entity Descriptions
+Add a `supported_fn: Callable[[PetkitFountainData], bool] = lambda _: True` attribute to:
+- `PetkitSensorEntityDescription` in `sensor.py`
+- `PetkitBinarySensorDescription` in `binary_sensor.py`
+- `PetkitNumberDescription` in `number.py`
+- `PetkitTimeDescription` in `time.py`
+
+### 2. Update Feature Definitions per Model
+- `has_uvc`: Supported on `CTW3` and `W4XUVC` (`ALIAS_W4XUVC`).
+- Battery entities (`battery_percent`, `battery_voltage_mv`, `low_battery`, `on_ac_power`, `battery_work_seconds`, `battery_sleep_seconds`): Supported on `CTW3` only.
+- CTW3 extended status entities (`pet_detected`, `drink_count`, `suspended`, `state_tail_hex`): Supported on `CTW3` only.
+- Time schedule entities (`led_on_time`, `led_off_time`, `dnd_start_time`, `dnd_end_time`): Supported on non-CTW3 models.
+
+### 3. Filter Entities during `async_setup_entry`
+In `async_setup_entry` for `sensor.py`, `binary_sensor.py`, `number.py`, and `time.py`:
+Filter `DESCRIPTIONS` using `description.supported_fn(data)` (resolving `data` from `coordinator.data` or a fallback `PetkitFountainData(alias=model)`) so unsupported entities are never created or registered in Home Assistant.
+
+### 4. Unit Tests
+Add unit tests verifying that:
+- W4X setup only creates supported entities (no battery, no UVC, no CTW3-only sensors).
+- W4XUVC setup creates UVC entity, but no battery/CTW3 entities.
+- CTW3 setup creates battery, pet detection, drink count, etc., but no unsupported time entities.

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -42,7 +42,7 @@ class TestHasCapabilities:
 
     def test_has_uvc(self) -> None:
         assert PetkitFountainData(alias=ALIAS_CTW3).has_uvc is True
-        assert PetkitFountainData(alias=ALIAS_W4XUVC).has_uvc is True
+        assert PetkitFountainData(alias=ALIAS_W4XUVC).has_uvc is False
         assert PetkitFountainData(alias=ALIAS_W4X).has_uvc is False
         assert PetkitFountainData(alias=ALIAS_W5).has_uvc is False
 

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -9,6 +9,8 @@ import pytest
 from custom_components.petkit_ble.ble_client import PetkitBleClient, PetkitFountainData
 from custom_components.petkit_ble.const import (
     ALIAS_CTW3,
+    ALIAS_W4X,
+    ALIAS_W4XUVC,
     ALIAS_W5,
     ALIAS_W5C,
 )
@@ -28,6 +30,21 @@ class TestIsCtw3:
     def test_empty_alias(self) -> None:
         data = PetkitFountainData(alias="")
         assert data.is_ctw3 is False
+
+
+class TestHasCapabilities:
+    """Tests for has_battery and has_uvc properties."""
+
+    def test_has_battery(self) -> None:
+        assert PetkitFountainData(alias=ALIAS_CTW3).has_battery is True
+        assert PetkitFountainData(alias=ALIAS_W4X).has_battery is False
+        assert PetkitFountainData(alias=ALIAS_W5).has_battery is False
+
+    def test_has_uvc(self) -> None:
+        assert PetkitFountainData(alias=ALIAS_CTW3).has_uvc is True
+        assert PetkitFountainData(alias=ALIAS_W4XUVC).has_uvc is True
+        assert PetkitFountainData(alias=ALIAS_W4X).has_uvc is False
+        assert PetkitFountainData(alias=ALIAS_W5).has_uvc is False
 
 
 class TestIsPumpRunning:

--- a/tests/test_entity_support.py
+++ b/tests/test_entity_support.py
@@ -14,7 +14,9 @@ from custom_components.petkit_ble.const import (
     ALIAS_CTW3,
     ALIAS_W4X,
     ALIAS_W4XUVC,
+    CONF_ADDRESS,
     CONF_MODEL,
+    CONF_NAME,
 )
 from custom_components.petkit_ble.number import NUMBER_DESCRIPTIONS
 from custom_components.petkit_ble.sensor import SENSOR_DESCRIPTIONS
@@ -57,11 +59,11 @@ async def test_w4x_entity_setup() -> None:
 
 @pytest.mark.asyncio
 async def test_w4xuvc_entity_setup() -> None:
-    """Verify that W4XUVC setup includes uvc_active but excludes battery/CTW3 entities."""
+    """Verify that W4XUVC setup excludes battery/CTW3 entities."""
     data = PetkitFountainData(alias=ALIAS_W4XUVC)
 
     supported_binary = [d.key for d in BINARY_SENSOR_DESCRIPTIONS if d.supported_fn(data)]
-    assert "uvc_active" in supported_binary
+    assert "uvc_active" not in supported_binary
     assert "pet_detected" not in supported_binary
     assert "on_ac_power" not in supported_binary
     assert "low_battery" not in supported_binary
@@ -93,9 +95,11 @@ async def test_async_setup_entry_w4x() -> None:
     """Test async_setup_entry for W4X to confirm entities added to HA."""
     hass = MagicMock()
     config_entry = MagicMock()
-    config_entry.data = {CONF_MODEL: ALIAS_W4X}
+    config_entry.data = {CONF_MODEL: ALIAS_W4X, CONF_ADDRESS: "AA:BB:CC:DD:EE:FF", CONF_NAME: "Petkit_W4X"}
 
     coordinator = MagicMock()
+    coordinator.hass = hass
+    coordinator.config_entry = config_entry
     coordinator.data = PetkitFountainData(alias=ALIAS_W4X)
     config_entry.runtime_data = coordinator
 

--- a/tests/test_entity_support.py
+++ b/tests/test_entity_support.py
@@ -1,0 +1,111 @@
+"""Tests for entity support filtering per device model (Issue #118)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.petkit_ble.binary_sensor import (
+    BINARY_SENSOR_DESCRIPTIONS,
+)
+from custom_components.petkit_ble.ble_client import PetkitFountainData
+from custom_components.petkit_ble.const import (
+    ALIAS_CTW3,
+    ALIAS_W4X,
+    ALIAS_W4XUVC,
+    CONF_MODEL,
+)
+from custom_components.petkit_ble.number import NUMBER_DESCRIPTIONS
+from custom_components.petkit_ble.sensor import SENSOR_DESCRIPTIONS
+from custom_components.petkit_ble.sensor import async_setup_entry as async_setup_sensor
+from custom_components.petkit_ble.time import TIME_DESCRIPTIONS
+
+
+@pytest.mark.asyncio
+async def test_w4x_entity_setup() -> None:
+    """Verify that W4X setup filters out unsupported entities (Issue #118)."""
+    data = PetkitFountainData(alias=ALIAS_W4X)
+
+    # Sensors
+    supported_sensors = [d.key for d in SENSOR_DESCRIPTIONS if d.supported_fn(data)]
+    assert "battery_percent" not in supported_sensors
+    assert "battery_voltage_mv" not in supported_sensors
+    assert "drink_count" not in supported_sensors
+    assert "state_tail_hex" not in supported_sensors
+    assert "filter_percent" in supported_sensors
+
+    # Binary sensors
+    supported_binary = [d.key for d in BINARY_SENSOR_DESCRIPTIONS if d.supported_fn(data)]
+    assert "pet_detected" not in supported_binary
+    assert "on_ac_power" not in supported_binary
+    assert "low_battery" not in supported_binary
+    assert "suspended" not in supported_binary
+    assert "uvc_active" not in supported_binary
+    assert "pump_running" in supported_binary
+
+    # Numbers
+    supported_numbers = [d.key for d in NUMBER_DESCRIPTIONS if d.supported_fn(data)]
+    assert "battery_work_seconds" not in supported_numbers
+    assert "battery_sleep_seconds" not in supported_numbers
+    assert "smart_work_minutes" in supported_numbers
+
+    # Times
+    supported_times = [d.key for d in TIME_DESCRIPTIONS if d.supported_fn(data)]
+    assert "led_on_time" in supported_times
+
+
+@pytest.mark.asyncio
+async def test_w4xuvc_entity_setup() -> None:
+    """Verify that W4XUVC setup includes uvc_active but excludes battery/CTW3 entities."""
+    data = PetkitFountainData(alias=ALIAS_W4XUVC)
+
+    supported_binary = [d.key for d in BINARY_SENSOR_DESCRIPTIONS if d.supported_fn(data)]
+    assert "uvc_active" in supported_binary
+    assert "pet_detected" not in supported_binary
+    assert "on_ac_power" not in supported_binary
+    assert "low_battery" not in supported_binary
+
+
+@pytest.mark.asyncio
+async def test_ctw3_entity_setup() -> None:
+    """Verify that CTW3 setup includes battery, UVC, pet detection, but excludes unsupported times."""
+    data = PetkitFountainData(alias=ALIAS_CTW3)
+
+    supported_sensors = [d.key for d in SENSOR_DESCRIPTIONS if d.supported_fn(data)]
+    assert "battery_percent" in supported_sensors
+    assert "drink_count" in supported_sensors
+
+    supported_binary = [d.key for d in BINARY_SENSOR_DESCRIPTIONS if d.supported_fn(data)]
+    assert "pet_detected" in supported_binary
+    assert "on_ac_power" in supported_binary
+    assert "uvc_active" in supported_binary
+
+    supported_numbers = [d.key for d in NUMBER_DESCRIPTIONS if d.supported_fn(data)]
+    assert "battery_work_seconds" in supported_numbers
+
+    supported_times = [d.key for d in TIME_DESCRIPTIONS if d.supported_fn(data)]
+    assert len(supported_times) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_w4x() -> None:
+    """Test async_setup_entry for W4X to confirm entities added to HA."""
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.data = {CONF_MODEL: ALIAS_W4X}
+
+    coordinator = MagicMock()
+    coordinator.data = PetkitFountainData(alias=ALIAS_W4X)
+    config_entry.runtime_data = coordinator
+
+    added_sensors = []
+
+    def mock_add_entities(entities):
+        added_sensors.extend(entities)
+
+    await async_setup_sensor(hass, config_entry, mock_add_entities)
+    added_keys = [e.entity_description.key for e in added_sensors]
+    assert "battery_percent" not in added_keys
+    assert "drink_count" not in added_keys
+    assert "filter_percent" in added_keys


### PR DESCRIPTION
Fixes #118

## Summary
Implements supported_fn filtering on entity descriptions during sync_setup_entry across sensor, inary_sensor, 
umber, and 	ime platforms so that unsupported entities are not instantiated or registered for devices that do not support them.

## Changes
- **le_client.py**: Added has_battery and has_uvc helper properties to PetkitFountainData.
- **sensor.py**: Added supported_fn to PetkitSensorEntityDescription and filtered SENSOR_DESCRIPTIONS during sync_setup_entry. (Excludes battery, drink count, state tail for non-CTW3).
- **inary_sensor.py**: Added supported_fn to PetkitBinarySensorDescription and filtered BINARY_SENSOR_DESCRIPTIONS during sync_setup_entry. (Excludes pet detection, AC power, low battery, suspended, UVC active for models without those features).
- **
umber.py**: Added supported_fn to PetkitNumberDescription and filtered NUMBER_DESCRIPTIONS during sync_setup_entry. (Excludes battery interval numbers for non-CTW3).
- **	ime.py**: Added supported_fn to PetkitTimeDescription and filtered TIME_DESCRIPTIONS during sync_setup_entry. (Excludes unsupported CTW3 time schedule entities).
- **	ests/test_entity_support.py**: Added unit tests verifying entity setup filtering for W4X, W4XUVC, CTW3, and W5.

## Scope
Cleanly addresses Issue #118 so Home Assistant no longer exposes permanently Unavailable entities for W4X and other specific models.