### PR TITLE
fix: restore mode select state across restarts & cap CTW3 LED brightness

### DIFF
--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -110,7 +110,11 @@ def _reconcile_settings_into(
     return warned
 
 
-def _reconcile_mode_into(data: PetkitFountainData, cached_mode: int | None) -> int | None:
+def _reconcile_mode_into(
+    data: PetkitFountainData,
+    cached_mode: int | None,
+    store: Any | None = None,
+) -> int | None:
     """Keep the last known mode when the device reports an unknown value.
 
     Generic W4/W5/CTW2 devices and CTW3 can both report ``0`` while the pump
@@ -118,12 +122,47 @@ def _reconcile_mode_into(data: PetkitFountainData, cached_mode: int | None) -> i
     we preserve the last known valid mode across polls instead of letting the
     UI fall back to ``unknown`` or the dataclass default.
     """
+    new_mode = cached_mode
     if data.mode in (MODE_NORMAL, MODE_SMART):
-        return data.mode
-    if cached_mode in (MODE_NORMAL, MODE_SMART):
+        new_mode = data.mode
+    elif cached_mode in (MODE_NORMAL, MODE_SMART):
         data.mode = cached_mode
-        return cached_mode
+
+    if new_mode in (MODE_NORMAL, MODE_SMART) and new_mode != cached_mode and store is not None:
+        _save_mode_state_into(store, new_mode)
+
+    return new_mode
+
+
+async def _load_mode_state_into(store: Any) -> int | None:
+    """Load the persisted mode from a ``Store`` snapshot if one exists.
+
+    Storage failures are swallowed at debug level — they must never block
+    integration setup. Invalid modes are discarded.
+    """
+    try:
+        stored = await store.async_load()
+    except Exception as exc:
+        _LOGGER.debug("Failed to load mode store: %s", exc)
+        return None
+    if not stored or not isinstance(stored, dict):
+        return None
+    try:
+        mode = int(stored.get("mode", 0))
+    except (TypeError, ValueError) as exc:
+        _LOGGER.debug("Discarding corrupt mode store: %s", exc)
+        return None
+    if mode in (MODE_NORMAL, MODE_SMART):
+        return mode
     return None
+
+
+def _save_mode_state_into(store: Any, mode: int) -> None:
+    """Schedule saving the mode state to ``Store``."""
+    try:
+        store.async_delay_save(lambda: {"mode": mode}, 5.0)
+    except Exception as exc:
+        _LOGGER.debug("Failed to save mode store: %s", exc)
 
 
 # Byte indices in the CMD 210 payload that are known to change every poll
@@ -274,6 +313,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         # and colons are invalid on some filesystems (notably Windows).
         self._drink_state = _DrinkCountState(date_iso=dt_util.now().date().isoformat())
         self._drink_store: Store = Store(hass, version=1, key=f"{DOMAIN}_drink_count_{config_entry.entry_id}")
+        self._mode_store: Store = Store(hass, version=1, key=f"{DOMAIN}_mode_{config_entry.entry_id}")
 
         # Cache for settings fields (CMD 211 / CMD 221). See _SETTINGS_FIELDS
         # docstring for rationale. Populated either by a successful CMD 211
@@ -298,12 +338,14 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         )
 
     async def async_load_persistent_state(self) -> None:
-        """Load the persisted drink-event counter from disk.
+        """Load the persisted drink-event counter and mode from disk.
 
         Called once before the first refresh so a Home Assistant restart or
-        integration reload no longer wipes today's count to zero.
+        integration reload no longer wipes today's count to zero or loses the
+        last known operation mode.
         """
         await _load_drink_state_into(self._drink_state, self._drink_store)
+        self._mode_cache = await _load_mode_state_into(self._mode_store)
 
     async def _track_drink_event(self, data: PetkitFountainData) -> None:
         """Thin wrapper around ``_track_drink_event_into`` for the poll loop."""
@@ -466,7 +508,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
             self._prev_raw_state = data.raw_state
 
         self._reconcile_settings(data)
-        self._mode_cache = _reconcile_mode_into(data, self._mode_cache)
+        self._mode_cache = _reconcile_mode_into(data, self._mode_cache, self._mode_store)
 
         # Self-heal persistence: if the BLE client inferred a corrected alias
         # from the CMD 210 payload (e.g. when the original entry stored a MAC
@@ -561,6 +603,8 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         if mode not in (MODE_NORMAL, MODE_SMART):
             _LOGGER.debug("apply_mode_optimistic: invalid mode %r ignored", mode)
             return
+        if self._mode_cache != mode:
+            _save_mode_state_into(self._mode_store, mode)
         self._mode_cache = mode
         if self.data is not None:
             self.data.mode = mode

--- a/custom_components/petkit_ble/number.py
+++ b/custom_components/petkit_ble/number.py
@@ -29,6 +29,7 @@ class PetkitNumberDescription(NumberEntityDescription):
     """Number description with value extractor and setter field name."""
 
     value_fn: Callable[[PetkitFountainData], float | None]
+    max_value_fn: Callable[[PetkitFountainData], float] | None = None
     supported_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     available_fn: Callable[[PetkitFountainData], bool] = lambda _: True
     field_name: str
@@ -60,6 +61,7 @@ NUMBER_DESCRIPTIONS: tuple[PetkitNumberDescription, ...] = (
         translation_key="led_brightness",
         native_min_value=1,
         native_max_value=10,
+        max_value_fn=lambda d: 3.0 if d.is_ctw3 else 10.0,
         native_step=1,
         mode=NumberMode.SLIDER,
         value_fn=lambda d: d.led_brightness,
@@ -123,6 +125,13 @@ class PetkitBleNumber(PetkitBleEntity, NumberEntity):
         if not super().available:
             return False
         return self.entity_description.available_fn(self.coordinator.data)
+
+    @property
+    def native_max_value(self) -> float | None:
+        """Return the maximum value, dynamically calculated per model when applicable."""
+        if self.entity_description.max_value_fn is not None and self.coordinator.data is not None:
+            return self.entity_description.max_value_fn(self.coordinator.data)
+        return self.entity_description.native_max_value
 
     @property
     def native_value(self) -> float | None:

--- a/tests/test_mode_persistence.py
+++ b/tests/test_mode_persistence.py
@@ -1,0 +1,136 @@
+"""Tests for mode select state persistence across Home Assistant restarts.
+
+Covers behaviour added for Issue #111 / #122:
+
+- ``_load_mode_state_into`` restores stored mode (1=normal, 2=smart) at setup.
+- ``_reconcile_mode_into`` preserves cached mode when raw mode is 0 and saves mode changes.
+- Storage exceptions or corrupt values are safely handled without breaking setup/polling.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.petkit_ble.ble_client import PetkitFountainData
+from custom_components.petkit_ble.const import ALIAS_CTW3, MODE_NORMAL, MODE_SMART
+from custom_components.petkit_ble.coordinator import (
+    _load_mode_state_into,
+    _reconcile_mode_into,
+    _save_mode_state_into,
+)
+
+
+def _make_store() -> MagicMock:
+    """Build a Store mock whose async methods are awaitable."""
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save = AsyncMock()
+    return store
+
+
+class TestModeLoadPersistence:
+    """Test loading mode state from Store."""
+
+    @pytest.mark.asyncio
+    async def test_load_restores_valid_normal_mode(self) -> None:
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"mode": MODE_NORMAL})
+
+        mode = await _load_mode_state_into(store)
+        assert mode == MODE_NORMAL
+
+    @pytest.mark.asyncio
+    async def test_load_restores_valid_smart_mode(self) -> None:
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"mode": MODE_SMART})
+
+        mode = await _load_mode_state_into(store)
+        assert mode == MODE_SMART
+
+    @pytest.mark.asyncio
+    async def test_load_handles_missing_store(self) -> None:
+        store = _make_store()
+        store.async_load = AsyncMock(return_value=None)
+
+        mode = await _load_mode_state_into(store)
+        assert mode is None
+
+    @pytest.mark.asyncio
+    async def test_load_handles_invalid_mode_value(self) -> None:
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"mode": 99})
+
+        mode = await _load_mode_state_into(store)
+        assert mode is None
+
+    @pytest.mark.asyncio
+    async def test_load_handles_corrupt_store(self) -> None:
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"mode": "invalid"})
+
+        mode = await _load_mode_state_into(store)
+        assert mode is None
+
+    @pytest.mark.asyncio
+    async def test_load_swallows_exceptions(self) -> None:
+        store = _make_store()
+        store.async_load = AsyncMock(side_effect=RuntimeError("disk failure"))
+
+        mode = await _load_mode_state_into(store)
+        assert mode is None
+
+
+class TestModeReconciliationAndSave:
+    """Test mode reconciliation and scheduling delayed save."""
+
+    def test_reconcile_applies_data_mode_and_saves_when_new(self) -> None:
+        store = _make_store()
+        data = PetkitFountainData(alias=ALIAS_CTW3, mode=MODE_SMART)
+
+        new_mode = _reconcile_mode_into(data, cached_mode=None, store=store)
+        assert new_mode == MODE_SMART
+        assert data.mode == MODE_SMART
+        store.async_delay_save.assert_called_once()
+
+    def test_reconcile_retains_cached_mode_when_data_mode_is_zero(self) -> None:
+        store = _make_store()
+        # Initial poll returns mode=0 because pump is off/sleeping
+        data = PetkitFountainData(alias=ALIAS_CTW3, mode=0)
+
+        new_mode = _reconcile_mode_into(data, cached_mode=MODE_NORMAL, store=store)
+        assert new_mode == MODE_NORMAL
+        assert data.mode == MODE_NORMAL
+        # Mode did not change from cached_mode so store save is not called again
+        store.async_delay_save.assert_not_called()
+
+    def test_reconcile_handles_store_save_exception(self) -> None:
+        store = _make_store()
+        store.async_delay_save.side_effect = RuntimeError("disk full")
+        data = PetkitFountainData(alias=ALIAS_CTW3, mode=MODE_NORMAL)
+
+        # Must not raise exception
+        new_mode = _reconcile_mode_into(data, cached_mode=None, store=store)
+        assert new_mode == MODE_NORMAL
+
+
+def test_save_mode_state_into_schedules_save() -> None:
+    store = _make_store()
+    _save_mode_state_into(store, MODE_SMART)
+
+    store.async_delay_save.assert_called_once()
+    save_func = store.async_delay_save.call_args[0][0]
+    assert save_func() == {"mode": MODE_SMART}
+
+
+def test_led_brightness_max_value_ctw3_vs_generic() -> None:
+    from custom_components.petkit_ble.const import ALIAS_W5
+    from custom_components.petkit_ble.number import NUMBER_DESCRIPTIONS
+
+    desc = next(d for d in NUMBER_DESCRIPTIONS if d.key == "led_brightness")
+    ctw3_data = PetkitFountainData(alias=ALIAS_CTW3)
+    w5_data = PetkitFountainData(alias=ALIAS_W5)
+
+    assert desc.max_value_fn(ctw3_data) == 3.0
+    assert desc.max_value_fn(w5_data) == 10.0


### PR DESCRIPTION
Fixes #111 (#122) and #123.

### Changes Included:
1. **Mode Select Persistence across Restarts (Issue #111):**
   - Added `_mode_store` on `PetkitBleCoordinator` using Home Assistant's `Store` helper.
   - Restores the last known valid mode (`1=normal`, `2=smart`) prior to the first BLE refresh during setup (`async_load_persistent_state`).
   - Prevents the `select.mode` entity from displaying `Unknown` on Home Assistant restart/reload when the device reports `mode=0` while idle or sleeping.
   - Automatically saves mode updates from `_reconcile_mode_into` and `apply_mode_optimistic`.

2. **Per-Model LED Brightness Limits (Issue #123):**
   - Added `max_value_fn` support to `PetkitNumberDescription`.
   - Capped `led_brightness` `max_value` to `3` for CTW3 devices (`1..3`), as CTW3 firmware rejects higher values and reverts to `2`.
   - Retained `1..10` for non-CTW3 devices.

3. **Tests:**
   - Added unit tests in `tests/test_mode_persistence.py` covering mode loading, reconciliation, persistence error handling, and model-specific LED brightness maximums.