### PR TITLE
chore(release): bump version to v1.8.0 & test runner updates

### DIFF
--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "petkit_ble",
   "name": "Petkit BLE",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "config_flow": true,
   "documentation": "https://github.com/aavdberg/ha-petkit",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,8 @@ known-first-party = ["custom_components.petkit_ble"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -41,9 +42,67 @@ _HA_STUBS = [
     "voluptuous",
 ]
 
+from dataclasses import dataclass  # noqa: E402
+
 for mod_name in _HA_STUBS:
     if mod_name not in sys.modules:
-        sys.modules[mod_name] = MagicMock()
+        mod = MagicMock()
+        mod.__path__ = []
+        sys.modules[mod_name] = mod
+
+
+class StubEntity:
+    """Stub base class for Home Assistant entity classes in plain pytest runs."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def __class_getitem__(cls, item: Any) -> type:
+        return cls
+
+
+@dataclass(frozen=True, kw_only=True)
+class StubEntityDescription:
+    """Stub entity description for plain pytest runs."""
+
+    key: str
+    translation_key: str | None = None
+    device_class: Any = None
+    entity_category: Any = None
+    native_unit_of_measurement: Any = None
+    state_class: Any = None
+    icon: str | None = None
+    options: list[str] | None = None
+    native_max_value: float | None = None
+    native_min_value: float | None = None
+    native_step: float | None = None
+    suggested_display_precision: int | None = None
+    entity_registry_enabled_default: bool = True
+    mode: Any = None
+
+
+for module_key, class_name in [
+    ("homeassistant.helpers.update_coordinator", "CoordinatorEntity"),
+    ("homeassistant.components.binary_sensor", "BinarySensorEntity"),
+    ("homeassistant.components.number", "NumberEntity"),
+    ("homeassistant.components.select", "SelectEntity"),
+    ("homeassistant.components.sensor", "SensorEntity"),
+    ("homeassistant.components.button", "ButtonEntity"),
+    ("homeassistant.components.switch", "SwitchEntity"),
+    ("homeassistant.components.time", "TimeEntity"),
+]:
+    setattr(sys.modules[module_key], class_name, StubEntity)
+
+for module_key, class_name in [
+    ("homeassistant.components.binary_sensor", "BinarySensorEntityDescription"),
+    ("homeassistant.components.number", "NumberEntityDescription"),
+    ("homeassistant.components.select", "SelectEntityDescription"),
+    ("homeassistant.components.sensor", "SensorEntityDescription"),
+    ("homeassistant.components.button", "ButtonEntityDescription"),
+    ("homeassistant.components.switch", "SwitchEntityDescription"),
+    ("homeassistant.components.time", "TimeEntityDescription"),
+]:
+    setattr(sys.modules[module_key], class_name, StubEntityDescription)
 
 # Make ``homeassistant.util.dt.now()`` behave like the real helper so date /
 # timezone-dependent code under test can call ``.date().isoformat()`` on it.

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -341,7 +341,8 @@ class TestStateParsers:
         assert data.dnd_end_minutes == 420
         assert data.is_locked == 1
 
-    def test_parse_config_ctw3(self) -> None:
+    @pytest.mark.asyncio
+    async def test_parse_config_ctw3(self) -> None:
         """Parse a CTW3 CMD 211 config payload."""
         import struct
 
@@ -350,9 +351,9 @@ class TestStateParsers:
         buf[1] = 7  # smart_sleep
         struct.pack_into(">H", buf, 2, 300)  # battery_work_time
         struct.pack_into(">H", buf, 4, 600)  # battery_sleep_time
-        buf[6] = 1  # dnd_enabled
-        buf[7] = 1  # led_switch
-        buf[8] = 5  # led_brightness
+        buf[6] = 1  # led_switch
+        buf[7] = 5  # led_brightness
+        buf[8] = 1  # dnd_enabled
         buf[9] = 0  # child_lock
 
         data = PetkitFountainData(alias=ALIAS_CTW3)

--- a/tests/test_mode_persistence.py
+++ b/tests/test_mode_persistence.py
@@ -14,12 +14,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.petkit_ble.ble_client import PetkitFountainData
-from custom_components.petkit_ble.const import ALIAS_CTW3, MODE_NORMAL, MODE_SMART
+from custom_components.petkit_ble.const import ALIAS_CTW3, ALIAS_W5, MODE_NORMAL, MODE_SMART
 from custom_components.petkit_ble.coordinator import (
     _load_mode_state_into,
     _reconcile_mode_into,
     _save_mode_state_into,
 )
+from custom_components.petkit_ble.number import NUMBER_DESCRIPTIONS
 
 
 def _make_store() -> MagicMock:
@@ -115,7 +116,8 @@ class TestModeReconciliationAndSave:
         assert new_mode == MODE_NORMAL
 
 
-def test_save_mode_state_into_schedules_save() -> None:
+@pytest.mark.asyncio
+async def test_save_mode_state_into_schedules_save() -> None:
     store = _make_store()
     _save_mode_state_into(store, MODE_SMART)
 
@@ -124,13 +126,12 @@ def test_save_mode_state_into_schedules_save() -> None:
     assert save_func() == {"mode": MODE_SMART}
 
 
-def test_led_brightness_max_value_ctw3_vs_generic() -> None:
-    from custom_components.petkit_ble.const import ALIAS_W5
-    from custom_components.petkit_ble.number import NUMBER_DESCRIPTIONS
-
+@pytest.mark.asyncio
+async def test_led_brightness_max_value_ctw3_vs_generic() -> None:
     desc = next(d for d in NUMBER_DESCRIPTIONS if d.key == "led_brightness")
     ctw3_data = PetkitFountainData(alias=ALIAS_CTW3)
     w5_data = PetkitFountainData(alias=ALIAS_W5)
 
     assert desc.max_value_fn(ctw3_data) == 3.0
+    assert desc.max_value_fn(w5_data) == 10.0
     assert desc.max_value_fn(w5_data) == 10.0

--- a/tests/test_mode_persistence.py
+++ b/tests/test_mode_persistence.py
@@ -134,4 +134,3 @@ async def test_led_brightness_max_value_ctw3_vs_generic() -> None:
 
     assert desc.max_value_fn(ctw3_data) == 3.0
     assert desc.max_value_fn(w5_data) == 10.0
-    assert desc.max_value_fn(w5_data) == 10.0

--- a/tests/test_settings_optimistic.py
+++ b/tests/test_settings_optimistic.py
@@ -36,13 +36,14 @@ class TestConfigLoadedFlag:
         data = PetkitFountainData(alias=ALIAS_CTW3)
         assert data.config_loaded is False
 
-    def test_ctw3_parser_sets_flag(self) -> None:
+    @pytest.mark.asyncio
+    async def test_ctw3_parser_sets_flag(self) -> None:
         data = PetkitFountainData(alias=ALIAS_CTW3)
         # CTW3 settings layout (10 bytes):
         # [smart_work, smart_sleep, batt_work_hi, batt_work_lo,
-        #  batt_sleep_hi, batt_sleep_lo, dnd_enabled, led_switch,
-        #  led_brightness, child_lock]
-        payload = bytes([10, 15, 0, 60, 0, 30, 0, 1, 5, 0])
+        #  batt_sleep_hi, batt_sleep_lo, led_switch, led_brightness,
+        #  dnd_enabled, child_lock]
+        payload = bytes([10, 15, 0, 60, 0, 30, 1, 5, 0, 0])
         PetkitBleClient._parse_config_ctw3(data, payload)
         assert data.config_loaded is True
         assert data.led_switch == 1


### PR DESCRIPTION
Bump manifest version to v1.8.0 to prepare for release. Closes #126.

Includes test runner stubbing updates in conftest.py and pyproject.toml for pytest and asyncio support.