### PR TITLE
chore: bump dev manifest version to 1.10.0 (#140)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -279,6 +279,10 @@ When promoting changes from `dev` to `main` for a release:
    squash** — the dev PR history must be preserved on `main`.
 7. Verify `release.yml` published a non-prerelease `vX.Y.0` GitHub
    Release.
+8. **Immediately after releasing to `main`**: Bump `manifest.json` on `dev`
+   to the next minor version (e.g. `1.10.0`) via a `chore` PR on `dev`.
+   This ensures subsequent beta builds on `dev` (`v1.10.0-beta.1`) have a higher
+   version number than the stable release (`v1.9.0`) so HACS beta users receive updates.
 
 ---
 

--- a/custom_components/petkit_ble/manifest.json
+++ b/custom_components/petkit_ble/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/aavdberg/ha-petkit/issues",
   "requirements": ["bleak>=0.22.0", "bleak-retry-connector>=3.0.0"],
-  "version": "1.9.0"
+  "version": "1.10.0"
 }


### PR DESCRIPTION
Closes #140

- Bumps manifest.json on dev to 1.10.0 so post-1.9.0 beta releases on dev (1.10.0-beta.1) are recognized as newer than stable 1.9.0.
- Updates copilot-instructions.md with rule to bump dev manifest version immediately after a stable release.