### PR TITLE
chore(templates): add timestamped timeline guideline to issue templates (#146)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -118,6 +118,7 @@ body:
       label: Logs & Debug Snippets
       description: |
         Please enable debug logging in integration options or add `custom_components.petkit_ble: debug` to your `configuration.yaml` and paste relevant logs here.
+        If possible, please include a brief timestamped timeline of your actions (e.g. `11:04:15` Turned ON, `11:04:30` Removed tank, `11:04:45` Replaced tank) so we can correlate your actions with log events.
       placeholder: Paste logs or petkit.log contents here...
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -78,6 +78,8 @@ body:
     id: additional_context
     attributes:
       label: Additional Context & Debug Logs
-      description: Add any screenshot, BLE captures, or `petkit.log` debug snippets if applicable. If attaching logs, please include a brief timestamped timeline of your actions (e.g. `11:04:15` Turned ON, `11:04:30` Changed mode) to help correlate actions with BLE events.
+      description: |
+        Add any screenshots, BLE captures, or `petkit.log` debug snippets if applicable.
+        If attaching logs, please include a brief timestamped timeline of your actions (e.g. `11:04:15` Turned ON, `11:04:30` Changed mode) to help correlate actions with BLE events.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -78,6 +78,6 @@ body:
     id: additional_context
     attributes:
       label: Additional Context & Debug Logs
-      description: Add any screenshot, BLE captures, or `petkit.log` debug snippets if applicable.
+      description: Add any screenshot, BLE captures, or `petkit.log` debug snippets if applicable. If attaching logs, please include a brief timestamped timeline of your actions (e.g. `11:04:15` Turned ON, `11:04:30` Changed mode) to help correlate actions with BLE events.
     validations:
       required: false


### PR DESCRIPTION
Closes #146

Adds a guideline in bug_report.yml and feature_request.yml asking users to provide a timestamped timeline of their actions when submitting debug logs.