### PR TITLE
feat: add cleaning guidance entities (days since clean sensor & reset clean button)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Communicates directly over BLE — no cloud, no API token, no Petkit account req
 
 ## Features
 
-- **Sensors**: filter life %, pump runtime, water purified, energy today, filter days remaining, battery (CTW3), RSSI
+- **Sensors**: filter life %, pump runtime, water purified, energy today, filter days remaining, days since clean, last cleaned, battery (CTW3), RSSI
 - **Binary sensors**: pump running, water missing, filter warning, hardware failure, DND, pet detected (CTW3), AC power (CTW3), low battery (CTW3), UVC active (CTW3)
 - **Select**: operating mode (Normal / Smart)
 - **Number**: Smart mode work & sleep duration (minutes), LED brightness (max 3 on CTW3, 10 on others), battery work & sleep duration in seconds (CTW3)
 - **Time**: Do Not Disturb (DND) start & end times, LED schedule start & end times (non-CTW3)
-- **Buttons**: reset filter, pump on, pump off
+- **Buttons**: reset filter, reset clean counter
 - **Switch**: power on/off
 - **ESPHome Bluetooth proxy support** — works transparently via Home Assistant's native Bluetooth stack
 

--- a/custom_components/petkit_ble/ble_client.py
+++ b/custom_components/petkit_ble/ble_client.py
@@ -8,6 +8,7 @@ import logging
 import math
 import struct
 from dataclasses import dataclass
+from datetime import datetime
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
@@ -104,6 +105,10 @@ class PetkitFountainData:
 
     # Drink statistics
     drink_event_count: int = 0
+
+    # Cleaning guidance
+    last_cleaned: datetime | None = None
+    days_since_clean: int | None = None
 
     # CMD 66 battery (raw ADC voltage, little-endian, for non-CTW3)
     battery_voltage_mv_66: int = 0

--- a/custom_components/petkit_ble/button.py
+++ b/custom_components/petkit_ble/button.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.button import ENTITY_ID_FORMAT, ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -21,7 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 class PetkitButtonDescription(ButtonEntityDescription):
     """Button description with press action."""
 
-    press_fn: Callable[[PetkitBleCoordinator], list[tuple[int, list[int]]]]
+    press_fn: Callable[[PetkitBleCoordinator], list[tuple[int, list[int]]]] | None = None
+    async_press_fn: Callable[[PetkitBleCoordinator], Coroutine[Any, Any, None]] | None = None
 
 
 def _reset_filter_cmds(_coordinator: PetkitBleCoordinator) -> list[tuple[int, list[int]]]:
@@ -33,6 +35,11 @@ BUTTON_DESCRIPTIONS: tuple[PetkitButtonDescription, ...] = (
         key="reset_filter",
         translation_key="reset_filter",
         press_fn=_reset_filter_cmds,
+    ),
+    PetkitButtonDescription(
+        key="reset_clean",
+        translation_key="reset_clean",
+        async_press_fn=lambda coordinator: coordinator.async_reset_last_cleaned(),
     ),
 )
 
@@ -62,11 +69,16 @@ class PetkitBleButton(PetkitBleEntity, ButtonEntity):
         self.entity_description = description
 
     async def async_press(self) -> None:
-        """Send the button command to the device."""
-        for cmd, data in self.entity_description.press_fn(self.coordinator):
-            success = await self.coordinator.async_send_command(cmd, data)
-            if not success:
-                _LOGGER.error("Failed to send CMD %d for %s", cmd, self.entity_description.key)
-                return
+        """Send the button command or execute action."""
+        if self.entity_description.async_press_fn is not None:
+            await self.entity_description.async_press_fn(self.coordinator)
+            return
 
-        await self.coordinator.async_request_refresh()
+        if self.entity_description.press_fn is not None:
+            for cmd, data in self.entity_description.press_fn(self.coordinator):
+                success = await self.coordinator.async_send_command(cmd, data)
+                if not success:
+                    _LOGGER.error("Failed to send CMD %d for %s", cmd, self.entity_description.key)
+                    return
+
+            await self.coordinator.async_request_refresh()

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -439,7 +439,7 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
 
         if self.data is not None:
             _apply_clean_state_into(self._clean_state, self.data)
-            self.async_update_listeners()
+            self.async_set_updated_data(self.data)
 
     async def _track_drink_event(self, data: PetkitFountainData) -> None:
         """Thin wrapper around ``_track_drink_event_into`` for the poll loop."""

--- a/custom_components/petkit_ble/coordinator.py
+++ b/custom_components/petkit_ble/coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.bluetooth import (
@@ -286,6 +286,82 @@ async def _track_drink_event_into(
             _LOGGER.debug("Failed to persist drink-count store: %s", exc)
 
 
+@dataclass
+class _LastCleanedState:
+    """Mutable holder for the last cleaned timestamp state.
+
+    Lives on the coordinator across polls. Extracted into a dataclass so the
+    persistence and calculation logic can be unit-tested via free functions
+    (``_load_clean_state_into`` / ``_apply_clean_state_into``) without
+    instantiating the full ``DataUpdateCoordinator``.
+    """
+
+    last_cleaned_iso: str = ""
+
+
+def _parse_iso_timestamp(raw_iso: str) -> datetime | None:
+    """Parse ISO timestamp string cleanly."""
+    if not raw_iso or not isinstance(raw_iso, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(raw_iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    except (TypeError, ValueError):
+        return None
+
+
+async def _load_clean_state_into(state: _LastCleanedState, store: Any) -> None:
+    """Populate ``state`` from a ``Store`` snapshot if one exists.
+
+    Storage failures are swallowed at debug level — they must never block
+    integration setup. Initializes to current time if store is missing or corrupt.
+    """
+    try:
+        stored = await store.async_load()
+    except Exception as exc:
+        _LOGGER.debug("Failed to load last-cleaned store: %s", exc)
+        stored = None
+
+    if stored and isinstance(stored, dict) and stored.get("last_cleaned"):
+        raw_iso = str(stored["last_cleaned"])
+        if _parse_iso_timestamp(raw_iso) is not None:
+            state.last_cleaned_iso = raw_iso
+            return
+
+    now_iso = dt_util.now().isoformat()
+    state.last_cleaned_iso = now_iso
+    try:
+        await store.async_save({"last_cleaned": now_iso})
+    except Exception as exc:
+        _LOGGER.debug("Failed to save initial last-cleaned store: %s", exc)
+
+
+def _apply_clean_state_into(
+    state: _LastCleanedState,
+    data: PetkitFountainData,
+) -> None:
+    """Calculate and set ``last_cleaned`` and ``days_since_clean`` on ``data``."""
+    if not state.last_cleaned_iso:
+        state.last_cleaned_iso = dt_util.now().isoformat()
+
+    cleaned_dt = _parse_iso_timestamp(state.last_cleaned_iso)
+    if cleaned_dt is None:
+        cleaned_dt = dt_util.now()
+        if isinstance(cleaned_dt, datetime) and cleaned_dt.tzinfo is None:
+            cleaned_dt = cleaned_dt.replace(tzinfo=UTC)
+        state.last_cleaned_iso = cleaned_dt.isoformat()
+
+    data.last_cleaned = cleaned_dt
+    now = dt_util.now()
+    if isinstance(now, datetime) and now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+
+    delta_seconds = max(0.0, (now - cleaned_dt).total_seconds())
+    data.days_since_clean = int(delta_seconds // 86400)
+
+
 class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
     """Coordinator that polls a Petkit fountain over BLE."""
 
@@ -315,6 +391,10 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         self._drink_store: Store = Store(hass, version=1, key=f"{DOMAIN}_drink_count_{config_entry.entry_id}")
         self._mode_store: Store = Store(hass, version=1, key=f"{DOMAIN}_mode_{config_entry.entry_id}")
 
+        # Track cleaning guidance state (last cleaned timestamp)
+        self._clean_state = _LastCleanedState()
+        self._clean_store: Store = Store(hass, version=1, key=f"{DOMAIN}_last_cleaned_{config_entry.entry_id}")
+
         # Cache for settings fields (CMD 211 / CMD 221). See _SETTINGS_FIELDS
         # docstring for rationale. Populated either by a successful CMD 211
         # parse or by an entity-driven write via apply_setting_optimistic().
@@ -338,14 +418,28 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         )
 
     async def async_load_persistent_state(self) -> None:
-        """Load the persisted drink-event counter and mode from disk.
+        """Load the persisted drink-event counter, mode, and last-cleaned timestamp from disk.
 
         Called once before the first refresh so a Home Assistant restart or
-        integration reload no longer wipes today's count to zero or loses the
-        last known operation mode.
+        integration reload no longer wipes today's count to zero, loses the
+        last known operation mode, or resets the last-cleaned timestamp.
         """
         await _load_drink_state_into(self._drink_state, self._drink_store)
         self._mode_cache = await _load_mode_state_into(self._mode_store)
+        await _load_clean_state_into(self._clean_state, self._clean_store)
+
+    async def async_reset_last_cleaned(self) -> None:
+        """Reset the last-cleaned timestamp to current time and persist."""
+        now_iso = dt_util.now().isoformat()
+        self._clean_state.last_cleaned_iso = now_iso
+        try:
+            await self._clean_store.async_save({"last_cleaned": now_iso})
+        except Exception as exc:
+            _LOGGER.debug("Failed to save last-cleaned store on reset: %s", exc)
+
+        if self.data is not None:
+            _apply_clean_state_into(self._clean_state, self.data)
+            self.async_update_listeners()
 
     async def _track_drink_event(self, data: PetkitFountainData) -> None:
         """Thin wrapper around ``_track_drink_event_into`` for the poll loop."""
@@ -532,6 +626,9 @@ class PetkitBleCoordinator(DataUpdateCoordinator[PetkitFountainData]):
         # Track drink events. Counter resets daily and persists across
         # restarts. See ``_track_drink_event`` for full rationale.
         await self._track_drink_event(data)
+
+        # Apply persistent cleaning guidance state
+        _apply_clean_state_into(self._clean_state, data)
 
         # RSSI from the most recent BLE advertisement (no connection required)
         service_info = async_last_service_info(self.hass, self._address, connectable=False)

--- a/custom_components/petkit_ble/sensor.py
+++ b/custom_components/petkit_ble/sensor.py
@@ -131,6 +131,21 @@ SENSOR_DESCRIPTIONS: tuple[PetkitSensorEntityDescription, ...] = (
         value_fn=lambda d: d.filter_days_remaining,
     ),
     PetkitSensorEntityDescription(
+        key="days_since_clean",
+        translation_key="days_since_clean",
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda d: d.days_since_clean,
+    ),
+    PetkitSensorEntityDescription(
+        key="last_cleaned",
+        translation_key="last_cleaned",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: d.last_cleaned,
+    ),
+    PetkitSensorEntityDescription(
         key="firmware",
         translation_key="firmware",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/petkit_ble/strings.json
+++ b/custom_components/petkit_ble/strings.json
@@ -41,5 +41,70 @@
       "repair_cancelled": "Re-pairing cancelled. The device was left untouched.",
       "unsupported_device": "This device model may not be fully supported by this integration. Please report this issue on GitHub with your device model and logs."
     }
+  },
+  "entity": {
+      "sensor": {
+        "filter_percent": {"name": "Filter Life"},
+        "pump_runtime_today": {"name": "Pump Runtime Today"},
+        "pump_runtime": {"name": "Total Pump Runtime"},
+        "battery_percent": {"name": "Battery"},
+        "battery_voltage_mv": {"name": "Battery Voltage"},
+        "water_purified_today": {"name": "Water Purified Today"},
+        "energy_today": {"name": "Energy Today"},
+        "power": {"name": "Power"},
+        "energy_today_wh": {"name": "Energy Today (Wh)"},
+        "filter_days_remaining": {"name": "Filter Days Remaining"},
+        "days_since_clean": {"name": "Days Since Cleaned"},
+        "last_cleaned": {"name": "Last Cleaned"},
+        "firmware": {"name": "Firmware"},
+        "hardware_version": {"name": "Hardware Version"},
+        "rssi": {"name": "Signal Strength"},
+        "drink_count": {"name": "Drink Events Today"},
+        "state_tail_hex": {"name": "CTW3 State Tail (hex)"}
+      },
+      "binary_sensor": {
+        "pump_running": {"name": "Pump Running"},
+        "warning_water_missing": {"name": "Water Missing"},
+        "warning_filter": {"name": "Filter Warning"},
+        "warning_breakdown": {"name": "Hardware Failure"},
+        "dnd_active": {"name": "Do Not Disturb"},
+        "pet_detected": {"name": "Pet Drinking"},
+        "on_ac_power": {"name": "AC Power"},
+        "low_battery": {"name": "Low Battery"},
+        "suspended": {"name": "Pump Suspended"},
+        "uvc_active": {"name": "UVC Sterilization"}
+      },
+      "button": {
+        "reset_filter": {"name": "Reset Filter"},
+        "reset_clean": {"name": "Reset Clean Counter"}
+      },
+      "number": {
+        "smart_work_minutes": {"name": "Smart Mode Work Time"},
+        "smart_sleep_minutes": {"name": "Smart Mode Sleep Time"},
+        "led_brightness": {"name": "LED Brightness"},
+        "battery_work_seconds": {"name": "Battery Work Duration"},
+        "battery_sleep_seconds": {"name": "Battery Sleep Duration"}
+      },
+      "time": {
+        "led_on_time": {"name": "LED On Time"},
+        "led_off_time": {"name": "LED Off Time"},
+        "dnd_start_time": {"name": "DND Start Time"},
+        "dnd_end_time": {"name": "DND End Time"}
+      },
+      "select": {
+        "mode": {
+          "name": "Mode",
+          "state": {
+            "normal": "Normal",
+            "smart": "Smart"
+          }
+        }
+      },
+      "switch": {
+        "power": {"name": "Power"},
+        "led": {"name": "LED"},
+        "do_not_disturb": {"name": "Do Not Disturb"},
+        "child_lock": {"name": "Child Lock"}
+      }
   }
 }

--- a/custom_components/petkit_ble/translations/en.json
+++ b/custom_components/petkit_ble/translations/en.json
@@ -67,6 +67,8 @@
       "power": {"name": "Power"},
       "energy_today_wh": {"name": "Energy Today (Wh)"},
       "filter_days_remaining": {"name": "Filter Days Remaining"},
+      "days_since_clean": {"name": "Days Since Cleaned"},
+      "last_cleaned": {"name": "Last Cleaned"},
       "firmware": {"name": "Firmware"},
       "hardware_version": {"name": "Hardware Version"},
       "rssi": {"name": "Signal Strength"},
@@ -86,7 +88,8 @@
       "uvc_active": {"name": "UVC Sterilization"}
     },
     "button": {
-      "reset_filter": {"name": "Reset Filter"}
+      "reset_filter": {"name": "Reset Filter"},
+      "reset_clean": {"name": "Reset Clean Counter"}
     },
     "number": {
       "smart_work_minutes": {"name": "Smart Mode Work Time"},

--- a/custom_components/petkit_ble/translations/nl.json
+++ b/custom_components/petkit_ble/translations/nl.json
@@ -67,6 +67,8 @@
       "power": {"name": "Vermogen"},
       "energy_today_wh": {"name": "Energieverbruik vandaag (Wh)"},
       "filter_days_remaining": {"name": "Resterende filterdagen"},
+      "days_since_clean": {"name": "Dagen sinds schoonmaak"},
+      "last_cleaned": {"name": "Laatst schoongemaakt"},
       "firmware": {"name": "Firmware"},
       "hardware_version": {"name": "Hardwareversie"},
       "rssi": {"name": "Signaalsterkte"},
@@ -86,7 +88,8 @@
       "uvc_active": {"name": "UVC-sterilisatie"}
     },
     "button": {
-      "reset_filter": {"name": "Filter resetten"}
+      "reset_filter": {"name": "Filter resetten"},
+      "reset_clean": {"name": "Schoonmaakteller resetten"}
     },
     "number": {
       "smart_work_minutes": {"name": "Smart-modus werktijd"},

--- a/custom_components/petkit_ble/translations/uk.json
+++ b/custom_components/petkit_ble/translations/uk.json
@@ -67,6 +67,8 @@
       "power": {"name": "Потужність"},
       "energy_today_wh": {"name": "Споживання енергії сьогодні (Вт·год)"},
       "filter_days_remaining": {"name": "Залишилось днів фільтра"},
+      "days_since_clean": {"name": "Днів з моменту очищення"},
+      "last_cleaned": {"name": "Останнє очищення"},
       "firmware": {"name": "Прошивка"},
       "hardware_version": {"name": "Версія апаратного забезпечення"},
       "rssi": {"name": "Рівень сигналу"},
@@ -86,7 +88,8 @@
       "uvc_active": {"name": "УФ-стерилізація"}
     },
     "button": {
-      "reset_filter": {"name": "Скинути фільтр"}
+      "reset_filter": {"name": "Скинути фільтр"},
+      "reset_clean": {"name": "Скинути лічильник очищення"}
     },
     "number": {
       "smart_work_minutes": {"name": "Час роботи смарт-режиму"},

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -16,6 +16,8 @@ This document details every entity provided by the **ha-petkit** integration, in
 | `energy_today` | Energy Today | `kWh` | All Models | Estimated electrical energy consumed today (calculated). |
 | `energy_today_wh` | Energy Today (Wh) | `Wh` | All Models | Estimated electrical energy consumed today in Watt-hours. |
 | `filter_days_remaining` | Filter Days Remaining | `d` | All Models | Estimated days before filter replacement is required. |
+| `days_since_clean` | Days Since Cleaned | `d` | All Models | Days elapsed since the water fountain was last cleaned. |
+| `last_cleaned` | Last Cleaned | timestamp | All Models | Timestamp when the fountain was last cleaned (diagnostic). |
 | `battery_percent` | Battery Level | `%` | CTW3 Only | Current battery state of charge. |
 | `battery_voltage_mv` | Battery Voltage | `mV` | CTW3 Only | Current battery terminal voltage in millivolts. |
 | `drink_count` | Drink Count | — | CTW3 Only | Number of drinking sessions recorded today. |
@@ -77,8 +79,9 @@ Where:
 - **`switch.<device>_do_not_disturb`**: Toggle Do Not Disturb mode ON or OFF (CMD 221).
 - **`switch.<device>_child_lock`**: Toggle button child lock ON or OFF (CMD 221).
 
-### Button
+### Buttons
 - **`button.<device>_reset_filter`**: Resets the internal filter life counter back to 100% (CMD 222).
+- **`button.<device>_reset_clean`**: Resets the last cleaned timestamp counter back to zero days.
 
 ### Select
 - **`select.<device>_mode`**: Choose between operating modes `normal` (continuous pumping) and `smart` (scheduled work/sleep intervals).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,7 @@ class StubEntityDescription:
 
 for module_key, class_name in [
     ("homeassistant.helpers.update_coordinator", "CoordinatorEntity"),
+    ("homeassistant.helpers.update_coordinator", "DataUpdateCoordinator"),
     ("homeassistant.components.binary_sensor", "BinarySensorEntity"),
     ("homeassistant.components.number", "NumberEntity"),
     ("homeassistant.components.select", "SelectEntity"),

--- a/tests/test_clean_tracking.py
+++ b/tests/test_clean_tracking.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,8 +10,9 @@ import pytest
 from custom_components.petkit_ble.ble_client import PetkitFountainData
 from custom_components.petkit_ble.const import ALIAS_CTW3
 from custom_components.petkit_ble.coordinator import (
-    _LastCleanedState,
+    PetkitBleCoordinator,
     _apply_clean_state_into,
+    _LastCleanedState,
     _load_clean_state_into,
 )
 
@@ -27,7 +28,7 @@ def _make_store() -> MagicMock:
 class TestCleanStateLoading:
     """State loading from Store snapshot."""
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_load_valid_timestamp(self) -> None:
         state = _LastCleanedState()
         store = _make_store()
@@ -39,7 +40,7 @@ class TestCleanStateLoading:
         assert state.last_cleaned_iso == valid_iso
         store.async_save.assert_not_awaited()
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_load_missing_store_initializes_and_saves(self) -> None:
         state = _LastCleanedState()
         store = _make_store()
@@ -50,7 +51,7 @@ class TestCleanStateLoading:
         assert state.last_cleaned_iso != ""
         store.async_save.assert_awaited_once()
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_load_corrupt_store_initializes_and_saves(self) -> None:
         state = _LastCleanedState()
         store = _make_store()
@@ -67,7 +68,7 @@ class TestCleanStateCalculation:
 
     def test_apply_clean_state_recent(self) -> None:
         data = PetkitFountainData(alias=ALIAS_CTW3)
-        now_dt = datetime.now(timezone.utc)
+        now_dt = datetime.now(UTC)
         three_days_ago = (now_dt - timedelta(days=3, hours=2)).isoformat()
         state = _LastCleanedState(last_cleaned_iso=three_days_ago)
 
@@ -78,7 +79,7 @@ class TestCleanStateCalculation:
 
     def test_apply_clean_state_today(self) -> None:
         data = PetkitFountainData(alias=ALIAS_CTW3)
-        now_dt = datetime.now(timezone.utc)
+        now_dt = datetime.now(UTC)
         two_hours_ago = (now_dt - timedelta(hours=2)).isoformat()
         state = _LastCleanedState(last_cleaned_iso=two_hours_ago)
 
@@ -91,16 +92,16 @@ class TestCleanStateCalculation:
 class TestResetCleanAction:
     """Reset last cleaned timestamp action."""
 
-    @pytest.mark.anyio
-    async def test_reset_cleaned_updates_state_and_saves(self) -> None:
-        state = _LastCleanedState(last_cleaned_iso="2026-08-01T00:00:00+00:00")
-        store = _make_store()
-        data = PetkitFountainData(alias=ALIAS_CTW3)
+    @pytest.mark.asyncio
+    async def test_coordinator_async_reset_last_cleaned(self) -> None:
+        coordinator = MagicMock()
+        coordinator.data = PetkitFountainData(alias=ALIAS_CTW3)
+        coordinator._clean_state = _LastCleanedState(last_cleaned_iso="2026-08-01T00:00:00+00:00")
+        coordinator._clean_store = _make_store()
+        coordinator.async_set_updated_data = MagicMock()
 
-        now_iso = datetime.now(timezone.utc).isoformat()
-        state.last_cleaned_iso = now_iso
-        await store.async_save({"last_cleaned": now_iso})
-        _apply_clean_state_into(state, data)
+        await PetkitBleCoordinator.async_reset_last_cleaned(coordinator)
 
-        assert data.days_since_clean == 0
-        store.async_save.assert_awaited_once()
+        assert coordinator.data.days_since_clean == 0
+        coordinator._clean_store.async_save.assert_awaited_once()
+        coordinator.async_set_updated_data.assert_called_once_with(coordinator.data)

--- a/tests/test_clean_tracking.py
+++ b/tests/test_clean_tracking.py
@@ -1,0 +1,106 @@
+"""Tests for cleaning guidance tracking and persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.petkit_ble.ble_client import PetkitFountainData
+from custom_components.petkit_ble.const import ALIAS_CTW3
+from custom_components.petkit_ble.coordinator import (
+    _LastCleanedState,
+    _apply_clean_state_into,
+    _load_clean_state_into,
+)
+
+
+def _make_store() -> MagicMock:
+    """Build a Store mock whose async methods are awaitable."""
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save = AsyncMock()
+    return store
+
+
+class TestCleanStateLoading:
+    """State loading from Store snapshot."""
+
+    @pytest.mark.anyio
+    async def test_load_valid_timestamp(self) -> None:
+        state = _LastCleanedState()
+        store = _make_store()
+        valid_iso = "2026-09-01T12:00:00+00:00"
+        store.async_load = AsyncMock(return_value={"last_cleaned": valid_iso})
+
+        await _load_clean_state_into(state, store)
+
+        assert state.last_cleaned_iso == valid_iso
+        store.async_save.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_load_missing_store_initializes_and_saves(self) -> None:
+        state = _LastCleanedState()
+        store = _make_store()
+        store.async_load = AsyncMock(return_value=None)
+
+        await _load_clean_state_into(state, store)
+
+        assert state.last_cleaned_iso != ""
+        store.async_save.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_load_corrupt_store_initializes_and_saves(self) -> None:
+        state = _LastCleanedState()
+        store = _make_store()
+        store.async_load = AsyncMock(return_value={"last_cleaned": "invalid-date"})
+
+        await _load_clean_state_into(state, store)
+
+        assert state.last_cleaned_iso != ""
+        store.async_save.assert_awaited_once()
+
+
+class TestCleanStateCalculation:
+    """Calculation of days_since_clean and last_cleaned."""
+
+    def test_apply_clean_state_recent(self) -> None:
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        now_dt = datetime.now(timezone.utc)
+        three_days_ago = (now_dt - timedelta(days=3, hours=2)).isoformat()
+        state = _LastCleanedState(last_cleaned_iso=three_days_ago)
+
+        _apply_clean_state_into(state, data)
+
+        assert data.days_since_clean == 3
+        assert isinstance(data.last_cleaned, datetime)
+
+    def test_apply_clean_state_today(self) -> None:
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+        now_dt = datetime.now(timezone.utc)
+        two_hours_ago = (now_dt - timedelta(hours=2)).isoformat()
+        state = _LastCleanedState(last_cleaned_iso=two_hours_ago)
+
+        _apply_clean_state_into(state, data)
+
+        assert data.days_since_clean == 0
+        assert isinstance(data.last_cleaned, datetime)
+
+
+class TestResetCleanAction:
+    """Reset last cleaned timestamp action."""
+
+    @pytest.mark.anyio
+    async def test_reset_cleaned_updates_state_and_saves(self) -> None:
+        state = _LastCleanedState(last_cleaned_iso="2026-08-01T00:00:00+00:00")
+        store = _make_store()
+        data = PetkitFountainData(alias=ALIAS_CTW3)
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        state.last_cleaned_iso = now_iso
+        await store.async_save({"last_cleaned": now_iso})
+        _apply_clean_state_into(state, data)
+
+        assert data.days_since_clean == 0
+        store.async_save.assert_awaited_once()


### PR DESCRIPTION
Closes #156. Implements item 2 of tracking issue #148.

### Summary
Adds cleaning guidance tracking for Petkit water fountains:
- sensor.<device>_days_since_clean (duration in days elapsed since last clean).
- sensor.<device>_last_cleaned (timestamp diagnostic sensor).
- button.<device>_reset_clean (resets last cleaned timestamp to current time).
- Persistent state saved to HA Store across Home Assistant restarts.
- Translations added for English, Dutch (nl), and Ukrainian (uk).
- Unit tests added in tests/test_clean_tracking.py.